### PR TITLE
Updating agents to be compatible with time-limit

### DIFF
--- a/src/anl_agents/anl2024/antiagents/antiagent.py
+++ b/src/anl_agents/anl2024/antiagents/antiagent.py
@@ -35,7 +35,13 @@ class AntiAgent(SAONegotiator):
         # are we bidding first according to the negotiation protocol?
         self.first = not self.nmi.negotiator_index(self.id)
         # number of negotiation rounds
-        self.deadline = self.nmi.n_steps
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        self.deadline = nsteps__
         # all opponent offer timestamps
         self.opp_times = []
         # all opponent offer own utilities

--- a/src/anl_agents/anl2024/susumu/nayesian2.py
+++ b/src/anl_agents/anl2024/susumu/nayesian2.py
@@ -128,7 +128,13 @@ class Nayesian2(SAONegotiator):
         self.predicted_best_u = self.pair_utilities[0, 0]
 
         self.acceptable_utility = 1
-        self.total_steps = self.nmi.n_steps
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        self.total_steps = nsteps__
         self.proposed_offers = 0
         self.recieved_offers = 0
         # print('ufun_initilize')

--- a/src/anl_agents/anl2024/takafam/shochan.py
+++ b/src/anl_agents/anl2024/takafam/shochan.py
@@ -1,16 +1,14 @@
-import random
-
 import numpy as np
 from negmas import nash_points, pareto_frontier
 from negmas import Outcome, ResponseType, SAONegotiator, SAOResponse, SAOState
 from scipy.optimize import curve_fit
-import matplotlib.pyplot as plt
 
 __all__ = ["Shochan"]
 
 
 def aspiration_function(t, mx, rv, e):
     return (mx - rv) * (1.0 - np.power(t, e)) + rv
+
 
 class Shochan(SAONegotiator):
     """A simple negotiator that uses curve fitting to learn the reserved value.
@@ -44,6 +42,7 @@ class Shochan(SAONegotiator):
           with our own reserved values when calculating the rational outcomes. This is the best case scenario for us because
           we have MORE negotiation power when the partner has LOWER utility.
     """
+
     def __init__(
         self,
         *args,
@@ -79,6 +78,7 @@ class Shochan(SAONegotiator):
         self._nash_factor = nash_factor
         self._best: Outcome = None  # type: ignore
         self.nidx = 0
+        assert self.opponent_ufun is not None
         self.opponent_ufun.reserved_value = 0.0
         self.lasttime = 1.0
         self.diffmean = 0.01
@@ -89,7 +89,6 @@ class Shochan(SAONegotiator):
         self.g4 = 0
         self.mode = 0
         self.plus = 0.10
-        
 
     def __call__(self, state: SAOState) -> SAOResponse:
         assert self.ufun and self.opponent_ufun
@@ -100,46 +99,53 @@ class Shochan(SAONegotiator):
         for i in range(len(self.opponent_times)):
             diff.append(self.opponent_times[i] - self.my_times[i])
         # diff = self.opponent_times - self.my_times
-        if(len(diff)==0):
-            diff_mean=0.01
+        if len(diff) == 0:
+            diff_mean = 0.01
         else:
             diff_mean = sum(diff) / len(diff)
-        
+
         self.diff_mean = diff_mean
 
-        asp = aspiration_function(state.relative_time / self.lasttime, 1.0, self.ufun.reserved_value, self.fe)
-        
+        asp = aspiration_function(
+            state.relative_time / self.lasttime, 1.0, self.ufun.reserved_value, self.fe
+        )
+
         self.e = self.fe + (1.0 - asp) * 100
 
         self.my_times.append(state.relative_time)
         if self.is_acceptable(state):
-            if((state.step)==0):
+            if (state.step) == 0:
                 one_step = 0.0001
             else:
                 one_step = (state.relative_time) / (state.step)
-            if(self.ufun(state.current_offer) >= self.ufun.reserved_value + self.plus):
+            if self.ufun(state.current_offer) >= self.ufun.reserved_value + self.plus:
                 return SAOResponse(ResponseType.ACCEPT_OFFER, state.current_offer)
-                
 
         else:
-            self.preoffer.append((self.ufun(state.current_offer),self.opponent_ufun(state.current_offer)))
+            self.preoffer.append(
+                (
+                    self.ufun(state.current_offer),
+                    self.opponent_ufun(state.current_offer),
+                )
+            )
         # The offering strategy
         # nash
         ufuns = (self.ufun, self.opponent_ufun)
-        if((state.step)==0):
+        if (state.step) == 0:
             one_step = 0.0001
         else:
             one_step = (state.relative_time) / (state.step)
         lasttime = (1.0 // one_step) * one_step
         self.lasttime = lasttime
         # The offering strategy
-            
+
         # nash
         ufuns = (self.ufun, self.opponent_ufun)
         # list all outcomes
+        assert self.ufun and self.ufun.outcome_space
         outcomes = list(self.ufun.outcome_space.enumerate_or_sample())
         # find the pareto-front and the nash point
-        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)
+        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)  # type: ignore
         frontier_outcomes = [outcomes[_] for _ in frontier_indices]
         my_frontier_utils = [_[0] for _ in frontier_utils]
         opp_frontier_utils = [_[1] for _ in frontier_utils]
@@ -155,7 +161,7 @@ class Shochan(SAONegotiator):
         # Set the acceptable utility limit
         self._min_acceptable = self.ufun.reserved_value
         self.y2 = self.ufun.reserved_value
-    
+
         # We only update our estimate of the rational list of outcomes if it is not set or
         # there is a change in estimated reserved value
         if (
@@ -165,71 +171,63 @@ class Shochan(SAONegotiator):
             # The rational set of outcomes sorted dependingly according to our utility function
             # and the opponent utility function (in that order).
             ave_nash = 1.0
-            if(len(my_frontier_utils)!=0):
+            if len(my_frontier_utils) != 0:
                 ave_nash = 0.0
-                min_nash = my_frontier_utils[0]+ opp_frontier_utils[0]
+                min_nash = my_frontier_utils[0] + opp_frontier_utils[0]
                 for i in frontier_utils:
                     ave_nash = ave_nash + i[0] + i[1]
-                    if(min_nash > i[0] + i[1]):
+                    if min_nash > i[0] + i[1]:
                         # print(min_nash)
                         # print(i[0] + i[1])
                         min_nash = i[0] + i[1]
                 ave_nash = ave_nash / len(my_frontier_utils)
-                
+
                 # print(min_nash)
 
-
-            self._outcomes = [
+            self._outcomes = [  # type: ignore
                 w
                 for u, w in zip(my_frontier_utils, frontier_outcomes)
                 if u >= self.ufun.reserved_value
-            ]     
-            self._outcomes2 = [
-                w
-                for u, w in zip(my_frontier_utils, frontier_outcomes)
-            ]     
+            ]
+            self._outcomes2 = [w for u, w in zip(my_frontier_utils, frontier_outcomes)]
 
             self._rational = sorted(
-                [
+                [  # type: ignore
                     (my_util, opp_util, _)
                     for _ in self._outcomes
                     if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-                    and (opp_util := float(self.opponent_ufun(_)))
-                    > 0
+                    and (opp_util := float(self.opponent_ufun(_))) > 0
                 ],
             )
-            self.nidx = len(self._rational)-1
+            self.nidx = len(self._rational) - 1
 
             self._opprational = sorted(
-                [
+                [  # type: ignore
                     (opp_util, my_util, _)
                     for _ in self._outcomes
                     if (my_util := float(self.ufun(_))) > 0
                     # if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-                    and (opp_util := float(self.opponent_ufun(_)))
-                    > 0
+                    and (opp_util := float(self.opponent_ufun(_))) > 0
                 ],
             )
 
             self._rational2 = sorted(
-                [
+                [  # type: ignore
                     (my_util, opp_util, _)
                     for _ in outcomes
                     if (my_util := float(self.ufun(_))) > 0
-                    and (opp_util := float(self.opponent_ufun(_)))
-                    > 0
+                    and (opp_util := float(self.opponent_ufun(_))) > 0
                 ],
             )
-            self.nidx = len(self._rational)-1
+            self.nidx = len(self._rational) - 1
 
             self._opprational2 = sorted(
-                [
+                [  # type: ignore
                     (opp_util, my_util, _)
                     for _ in outcomes
                     if (my_util := float(self.ufun(_))) > 0
                     # if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-                    and (opp_util := float(self.opponent_ufun(_)))
-                    > 0
+                    and (opp_util := float(self.opponent_ufun(_))) > 0
                 ],
             )
 
@@ -240,9 +238,9 @@ class Shochan(SAONegotiator):
             difx = x2 - x1
             dify = y1 - y2
             self.y2 = y2
-            if(difx - dify >= 0.2):
+            if difx - dify >= 0.2:
                 self.mode = 1
-            if(self.nmi.n_steps <= 50):
+            if self.nmi.n_steps is not None and self.nmi.n_steps <= 50:
                 self.mode = 1
             # print(self.mode)
             # x1 = int(x1*100)/100
@@ -253,14 +251,12 @@ class Shochan(SAONegotiator):
             #     print("nash")
             #     print(nash)
 
-        
             # print(self.nidx)
         # If there are no rational outcomes (i.e. our estimate of the opponent rv is very wrogn),
         # then just revert to offering our top offer
         max_rational = len(self._rational) - 1
         if not self._rational:
             return SAOResponse(ResponseType.REJECT_OFFER, self.ufun.best())
-        
 
         # find our aspiration level (value between 0 and 1) the higher the higher utility we require
         asp = aspiration_function(state.relative_time, 1.0, 0.0, self.e)
@@ -270,17 +266,13 @@ class Shochan(SAONegotiator):
 
         border = self.ufun.reserved_value
 
-
-
         myasp = aspiration_function(state.relative_time, 1.0, border, self.fe)
-
-
 
         myut = self.nash
         myut = self.ufun.reserved_value + 0.1
-        # myut = self.ufun.reserved_value 
+        # myut = self.ufun.reserved_value
         # if(state.step + 1 == self.nmi.n_steps or state.relative_time + 2 * one_step > 1.0):
-        if(state.relative_time + 3 * one_step > 1.0):
+        if state.relative_time + 3 * one_step > 1.0:
             # print("num")
             # print([len(self.opponent_utilities),len(self.my_utilities)])
             # print(self.nmi.n_steps)
@@ -288,11 +280,14 @@ class Shochan(SAONegotiator):
             opmin = sorted(self.opponent_utilities)[0]
             opmax = sorted(self.opponent_utilities)[-1]
             opmin2 = sorted(self.opponent_utilities)[1]
-            target = opmax - (opmax - opmin) * (state.relative_time) / (self.opponent_times[-1]) 
+            target = (
+                opmax
+                - (opmax - opmin) * (state.relative_time) / (self.opponent_times[-1])
+            )
             target2 = opmin - (opmin2 - opmin)
 
             indop = len(self._opprational2) - 1
-            if(nash):
+            if nash:
                 outcome4 = self.nasho
             else:
                 outcome4 = self._best
@@ -301,15 +296,15 @@ class Shochan(SAONegotiator):
             tttt = []
             ttttt = []
             # print(myut)
-            while(indop!=0):
-                if(myut <= self._opprational2[indop][1]):
+            while indop != 0:
+                if myut <= self._opprational2[indop][1]:
                     myut = self._opprational2[indop][1]
                     outcome = self._opprational2[indop][2]
                     tttt.append(self._opprational2[indop][1])
                     outcome4 = outcome
-                nextidx = max(indop-1, 0)
+                nextidx = max(indop - 1, 0)
                 ttttt.append(self._opprational2[indop][1])
-                if(self._opprational2[nextidx][0] >= target):
+                if self._opprational2[nextidx][0] >= target:
                     indop = nextidx
                 else:
                     break
@@ -324,9 +319,9 @@ class Shochan(SAONegotiator):
             # ufuns2 = (self.ufun, self.opponent_ufun)
             # # list all outcomes
             # outcomes = list(self.ufun.outcome_space.enumerate_or_sample())
-            # frontier_utils, frontier_indices = pareto_frontier(ufuns2, outcomes)
+            # frontier_utils, frontier_indices = pareto_frontier(ufuns2, outcomes) # type: ignore
             # nash2 = nash_points(ufuns2, frontier_utils)  # type: ignore
-            # # nash2 = 
+            # # nash2 =
             # if(nash):
             #     print("nash")
             #     print(nash)
@@ -334,37 +329,35 @@ class Shochan(SAONegotiator):
             #     print("nash2")
             #     print(nash2)
 
-
-            if(state.step <= 50):
-                if(self.ufun(self._best) > self.ufun.reserved_value + self.plus):
+            if state.step <= 50:
+                if self.ufun(self._best) > self.ufun.reserved_value + self.plus:
                     outcome = self._best
                 else:
                     outcome = self.nasho
                 # if(self.ufun(self._nasho) >= self.ufun(self._best))
-                
-                
+
             else:
-                if(nash):
+                if nash:
                     outcome = self.nasho
-                    if(self.ufun(self._best) >= self.ufun.reserved_value  + self.plus):
-                        if(self.ufun(self._best) <= self.ufun(outcome4)):
+                    if self.ufun(self._best) >= self.ufun.reserved_value + self.plus:
+                        if self.ufun(self._best) <= self.ufun(outcome4):
                             outcome = outcome4
                         else:
                             # print("aaa")
                             outcome = self._best
                         # if(len(self.opponent_utilities) == len(self.my_utilities)):
-                        if(self.opponent_utilities[-1] < self.opponent_utilities[-2]):
+                        if self.opponent_utilities[-1] < self.opponent_utilities[-2]:
                             # print([len(self.opponent_utilities),len(self.my_utilities)])
                             # print(self.nmi.n_steps)
-                            if(len(self.opponent_utilities) > len(self.my_utilities)):
+                            if len(self.opponent_utilities) > len(self.my_utilities):
                                 outcome = outcome4
                             else:
                                 outcome = self.nasho
                 else:
                     # print("nothing")
-                    if(self.ufun(self._best) >= self.ufun.reserved_value):
+                    if self.ufun(self._best) >= self.ufun.reserved_value:
                         outcome = self._best
-                        if(self.ufun(self._best) <= self.ufun(outcome4)):
+                        if self.ufun(self._best) <= self.ufun(outcome4):
                             outcome = outcome4
                     else:
                         outcome = self._opprational[self.nidx][2]
@@ -376,22 +369,23 @@ class Shochan(SAONegotiator):
             outcome = self.ufun.best()
             border = self.ufun.reserved_value
             border = self.y2
-            if(nash):
-                border = max(border,self.ufun(self.nasho))
-            if(self.mode==1):
+            if nash:
+                border = max(border, self.ufun(self.nasho))
+            if self.mode == 1:
                 myasp = aspiration_function(state.relative_time, 1.0, border, self.fe)
                 indmy = max_rational
-                while(indmy!=0):
-                    nextidx = max(indmy-1 , 0)
-                    if(self._rational[nextidx][0] >= myasp):
+                while indmy != 0:
+                    nextidx = max(indmy - 1, 0)
+                    if self._rational[nextidx][0] >= myasp:
                         indmy = nextidx
                     else:
                         break
-                
+
                 indx = indmy
                 outcome = self._rational[indx][-1]
 
-        self.my_utilities.append(self.ufun(outcome))
+        assert self.ufun
+        self.my_utilities.append(float(self.ufun(outcome)))
         return SAOResponse(ResponseType.REJECT_OFFER, outcome)
         # return SAOResponse(ResponseType.REJECT_OFFER, self.ufun.best())
 
@@ -403,24 +397,24 @@ class Shochan(SAONegotiator):
         # If there is no offer, there is nothing to accept
         if offer is None:
             return False
-        if((state.step)==0):
+        if (state.step) == 0:
             one_step = 0.0001
         else:
             one_step = (state.relative_time) / (state.step)
-        
-        
+
         if self._best is None:
             self._best = offer
         else:
-            if(self.ufun(offer) > self.ufun(self._best)):
+            if self.ufun(offer) > self.ufun(self._best):
                 self._best = offer
-            elif(self.ufun(offer) == self.ufun(self._best)):
-                if(self.opponent_ufun(offer) < self.opponent_ufun(self._best)):
+            elif self.ufun(offer) == self.ufun(self._best):
+                if self.opponent_ufun(offer) < self.opponent_ufun(self._best):
                     self._best = offer
 
         self.opponent_times.append(state.relative_time)
-        self.opponent_utilities.append(self.opponent_ufun(offer))
-                    
+        assert self.opponent_ufun
+        self.opponent_utilities.append(float(self.opponent_ufun(offer)))
+
         # Find the current aspiration level
         myasp = aspiration_function(
             state.relative_time, 1.0, self.ufun.reserved_value, self.e
@@ -432,30 +426,32 @@ class Shochan(SAONegotiator):
 
         pat = self.pat * self.lasttime
         border = self.ufun.reserved_value
-        if(state.relative_time >= pat):
-            myasp = aspiration_function(pat / self.lasttime, 1.0, self.ufun.reserved_value, self.fe)
-            ratio = (myasp - self.ufun.reserved_value) / ((self.lasttime - pat)*(self.lasttime - pat))
+        if state.relative_time >= pat:
+            myasp = aspiration_function(
+                pat / self.lasttime, 1.0, self.ufun.reserved_value, self.fe
+            )
+            ratio = (myasp - self.ufun.reserved_value) / (
+                (self.lasttime - pat) * (self.lasttime - pat)
+            )
             xd = (state.relative_time / self.lasttime) - pat
-            y = myasp - (ratio*xd*xd) 
-            border = max(border,y)
+            y = myasp - (ratio * xd * xd)
+            border = max(border, y)
         else:
             border = self.ufun.reserved_value
 
-
-
         myasp = aspiration_function(state.relative_time, 1.0, border, self.e)
 
-        if(state.relative_time + 1 * one_step > 1.0):
-        # if(state.step + 1 == self.nmi.n_steps or state.relative_time + 1 * one_step > 1.0):
+        if state.relative_time + 1 * one_step > 1.0:
+            # if(state.step + 1 == self.nmi.n_steps or state.relative_time + 1 * one_step > 1.0):
             # print(self.predict)
             # print("last")
             # print([len(self.opponent_utilities),len(self.my_utilities)])
             # print(self.nmi.n_steps)
             # print(state.relative_time)
-            if(float(self.ufun(offer)) >= self.ufun.reserved_value + self.plus):
-                if(self.opponent_utilities[-1] <= self.opponent_utilities[-2]):
+            if float(self.ufun(offer)) >= self.ufun.reserved_value + self.plus:
+                if self.opponent_utilities[-1] <= self.opponent_utilities[-2]:
                     return True
-                if(len(self.opponent_utilities) > len(self.my_utilities)):
+                if len(self.opponent_utilities) > len(self.my_utilities):
                     return True
                 # myasp = 0.0
 
@@ -465,2878 +461,7 @@ class Shochan(SAONegotiator):
         # the current aspiration
 
         # return ans
-        return (float(self.ufun(offer)) >= myasp)
-
-
-# ?代目 3rd
-# class Shochan(SAONegotiator):
-#     """A simple negotiator that uses curve fitting to learn the reserved value.
-
-#     Args:
-#         min_unique_utilities: Number of different offers from the opponent before starting to
-#                               attempt learning their reserved value.
-#         e: The concession exponent used for the agent's offering strategy
-#         stochasticity: The level of stochasticity in the offers.
-#         enable_logging: If given, a log will be stored  for the estimates.
-
-#     Remarks:
-
-#         - Assumes that the opponent is using a time-based offering strategy that offers
-#           the outcome at utility $u(t) = (u_0 - r) - r \\exp(t^e)$ where $u_0$ is the utility of
-#           the first offer (directly read from the opponent ufun), $e$ is an exponent that controls the
-#           concession rate and $r$ is the reserved value we want to learn.
-#         - After it receives offers with enough different utilities, it starts finding the optimal values
-#           for $e$ and $r$.
-#         - When it is time to respond, RVFitter, calculates the set of rational outcomes **for both agents**
-#           based on its knowledge of the opponent ufun (given) and reserved value (learned). It then applies
-#           the same concession curve defined above to concede over an ordered list of these outcomes.
-#         - Is this better than using the same concession curve on the outcome space without even trying to learn
-#           the opponent reserved value? Maybe sometimes but empirical evaluation shows that it is not in general.
-#         - Note that the way we check for availability of enough data for training is based on the uniqueness of
-#           the utility of offers from the opponent (for the opponent). Given that these are real values, this approach
-#           is suspect because of rounding errors. If two outcomes have the same utility they may appear to have different
-#           but very close utilities because or rounding errors (or genuine very small differences). Such differences should
-#           be ignored.
-#         - Note also that we start assuming that the opponent reserved value is 0.0 which means that we are only restricted
-#           with our own reserved values when calculating the rational outcomes. This is the best case scenario for us because
-#           we have MORE negotiation power when the partner has LOWER utility.
-#     """
-#     def __init__(
-#         self,
-#         *args,
-#         min_unique_utilities: int = 10,
-#         e: float = 17.5,
-#         stochasticity: float = 0.1,
-#         enable_logging: bool = False,
-#         nash_factor=0.1,
-#         **kwargs,
-#     ):
-#         super().__init__(*args, **kwargs)
-#         self.min_unique_utilities = min_unique_utilities
-#         self.e = e
-#         self.fe = e
-#         self.stochasticity = stochasticity
-#         # keeps track of times at which the opponent offers
-#         self.opponent_times: list[float] = []
-#         self.my_times: list[float] = []
-#         # keeps track of opponent utilities of its offers
-#         self.opponent_utilities: list[float] = []
-#         # keeps track of the our last estimate of the opponent reserved value
-#         self._past_oppnent_rv = 0.0
-#         # keeps track of the rational outcome set given our estimate of the
-#         # opponent reserved value and our knowledge of ours
-#         self._rational: list[tuple[float, float, Outcome]] = []
-#         self._enable_logging = enable_logging
-#         self.preoffer = []
-#         self.predict = []
-#         self.my_utilities: list[float] = []
-
-#         self._outcomes: list[Outcome] = []
-#         self._min_acceptable = float("inf")
-#         self._nash_factor = nash_factor
-#         self._best: Outcome = None  # type: ignore
-#         self.nidx = 0
-#         self.opponent_ufun.reserved_value = 0.0
-#         self.lasttime = 1.0
-#         self.diffmean = 0.01
-#         self.pat = 0.95
-#         self.g1 = 0
-#         self.g2 = 0
-#         self.g3 = 0
-#         self.g4 = 0
-#         self.mode = 0
-        
-
-#     def __call__(self, state: SAOState) -> SAOResponse:
-#         assert self.ufun and self.opponent_ufun
-#         # update the opponent reserved value in self.opponent_ufun
-#         # self.update_reserved_value(state)
-#         # rune the acceptance strategy and if the offer received is acceptable, accept it
-#         diff = []
-#         for i in range(len(self.opponent_times)):
-#             diff.append(self.opponent_times[i] - self.my_times[i])
-#         # diff = self.opponent_times - self.my_times
-#         if(len(diff)==0):
-#             diff_mean=0.01
-#         else:
-#             diff_mean = sum(diff) / len(diff)
-        
-#         self.diff_mean = diff_mean
-
-#         asp = aspiration_function(state.relative_time / self.lasttime, 1.0, self.ufun.reserved_value, self.fe)
-        
-#         self.e = self.fe + (1.0 - asp) * 100
-
-#         self.my_times.append(state.relative_time)
-#         if self.is_acceptable(state):
-#             if((state.step)==0):
-#                 one_step = 0.0001
-#             else:
-#                 one_step = (state.relative_time) / (state.step)
-#             if(self.ufun(state.current_offer) > self.ufun.reserved_value + 0.1):
-#                 return SAOResponse(ResponseType.ACCEPT_OFFER, state.current_offer)
-                
-
-#         else:
-#             self.preoffer.append((self.ufun(state.current_offer),self.opponent_ufun(state.current_offer)))
-#         # The offering strategy
-#         # nash
-#         ufuns = (self.ufun, self.opponent_ufun)
-#         if((state.step)==0):
-#             one_step = 0.0001
-#         else:
-#             one_step = (state.relative_time) / (state.step)
-#         lasttime = (1.0 // one_step) * one_step
-#         self.lasttime = lasttime
-#         # The offering strategy
-            
-#         # nash
-#         ufuns = (self.ufun, self.opponent_ufun)
-#         # list all outcomes
-#         outcomes = list(self.ufun.outcome_space.enumerate_or_sample())
-#         # find the pareto-front and the nash point
-#         frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)
-#         frontier_outcomes = [outcomes[_] for _ in frontier_indices]
-#         my_frontier_utils = [_[0] for _ in frontier_utils]
-#         opp_frontier_utils = [_[1] for _ in frontier_utils]
-#         # print(my_frontier_utils)
-#         nash = nash_points(ufuns, frontier_utils)  # type: ignore
-#         if nash:
-#             # find my utility at the Nash Bargaining Solution.
-#             self.nash = nash[0][0][0]
-#             self.nasho = frontier_outcomes[nash[0][1]]
-
-#         else:
-#             self.nash = 0.5 * (float(self.ufun.max()) + self.ufun.reserved_value)
-#         # Set the acceptable utility limit
-#         self._min_acceptable = self.ufun.reserved_value
-#         self.y2 = self.ufun.reserved_value
-    
-#         # We only update our estimate of the rational list of outcomes if it is not set or
-#         # there is a change in estimated reserved value
-#         if (
-#             not self._rational
-#             # or abs(self.opponent_ufun.reserved_value - self._past_oppnent_rv) > 1e-3
-#         ):
-#             # The rational set of outcomes sorted dependingly according to our utility function
-#             # and the opponent utility function (in that order).
-#             ave_nash = 1.0
-#             if(len(my_frontier_utils)!=0):
-#                 ave_nash = 0.0
-#                 min_nash = my_frontier_utils[0]+ opp_frontier_utils[0]
-#                 for i in frontier_utils:
-#                     ave_nash = ave_nash + i[0] + i[1]
-#                     if(min_nash > i[0] + i[1]):
-#                         # print(min_nash)
-#                         # print(i[0] + i[1])
-#                         min_nash = i[0] + i[1]
-#                 ave_nash = ave_nash / len(my_frontier_utils)
-                
-#                 # print(min_nash)
-
-
-#             self._outcomes = [
-#                 w
-#                 for u, w in zip(my_frontier_utils, frontier_outcomes)
-#                 if u >= self.ufun.reserved_value
-#             ]     
-#             self._outcomes2 = [
-#                 w
-#                 for u, w in zip(my_frontier_utils, frontier_outcomes)
-#             ]     
-
-#             self._rational = sorted(
-#                 [
-#                     (my_util, opp_util, _)
-#                     for _ in self._outcomes
-#                     if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#                     and (opp_util := float(self.opponent_ufun(_)))
-#                     > 0
-#                 ],
-#             )
-#             self.nidx = len(self._rational)-1
-
-#             self._opprational = sorted(
-#                 [
-#                     (opp_util, my_util, _)
-#                     for _ in self._outcomes
-#                     if (my_util := float(self.ufun(_))) > 0
-#                     # if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#                     and (opp_util := float(self.opponent_ufun(_)))
-#                     > 0
-#                 ],
-#             )
-
-#             self._rational2 = sorted(
-#                 [
-#                     (my_util, opp_util, _)
-#                     for _ in outcomes
-#                     if (my_util := float(self.ufun(_))) > 0
-#                     and (opp_util := float(self.opponent_ufun(_)))
-#                     > 0
-#                 ],
-#             )
-#             self.nidx = len(self._rational)-1
-
-#             self._opprational2 = sorted(
-#                 [
-#                     (opp_util, my_util, _)
-#                     for _ in outcomes
-#                     if (my_util := float(self.ufun(_))) > 0
-#                     # if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#                     and (opp_util := float(self.opponent_ufun(_)))
-#                     > 0
-#                 ],
-#             )
-
-#             y1 = self._rational2[-1][0]
-#             x1 = self._rational2[-1][1]
-#             y2 = self._opprational2[-1][1]
-#             x2 = self._opprational2[-1][0]
-#             difx = x2 - x1
-#             dify = y1 - y2
-#             self.y2 = y2
-#             if(difx - dify >= 0.2):
-#                 self.mode = 1
-#             if(self.nmi.n_steps <= 50):
-#                 self.mode = 1
-#             # print(self.mode)
-#             x1 = int(x1*100)/100
-#             x2 = int(x2*100)/100
-#             y1 = int(y1*100)/100
-#             y2 = int(y2*100)/100
-
-        
-#             # print(self.nidx)
-#         # If there are no rational outcomes (i.e. our estimate of the opponent rv is very wrogn),
-#         # then just revert to offering our top offer
-#         max_rational = len(self._rational) - 1
-#         if not self._rational:
-#             return SAOResponse(ResponseType.REJECT_OFFER, self.ufun.best())
-        
-
-#         # find our aspiration level (value between 0 and 1) the higher the higher utility we require
-#         asp = aspiration_function(state.relative_time, 1.0, 0.0, self.e)
-#         # find the index of the rational outcome at the aspiration level (in the rational set of outcomes)
-#         n_rational = len(self._rational)
-#         max_rational = n_rational - 1
-
-#         border = self.ufun.reserved_value
-
-
-
-#         myasp = aspiration_function(state.relative_time, 1.0, border, self.fe)
-
-
-
-#         myut = self.nash
-#         myut = self.ufun.reserved_value + 0.1
-#         # myut = self.ufun.reserved_value 
-#         # if(state.step + 1 == self.nmi.n_steps or state.relative_time + 2 * one_step > 1.0):
-#         if(state.relative_time + 3 * one_step > 1.0):
-#             opmin = sorted(self.opponent_utilities)[0]
-#             opmax = sorted(self.opponent_utilities)[-1]
-#             opmin2 = sorted(self.opponent_utilities)[1]
-#             target = opmax - (opmax - opmin) * (state.relative_time) / (self.opponent_times[-1]) 
-#             # target = opmin - (opmin2 - opmin)
-
-#             indop = len(self._opprational2) - 1
-#             if(nash):
-#                 outcome4 = self.nasho
-#             else:
-#                 outcome4 = self.best
-
-#             myut = self.ufun.reserved_value + 0.1
-#             tttt = []
-#             ttttt = []
-#             # print(myut)
-#             while(indop!=0):
-#                 if(myut <= self._opprational2[indop][1]):
-#                     myut = self._opprational2[indop][1]
-#                     outcome = self._opprational2[indop][2]
-#                     tttt.append(self._opprational2[indop][1])
-#                     outcome4 = outcome
-#                 nextidx = max(indop-1, 0)
-#                 ttttt.append(self._opprational2[indop][1])
-#                 if(self._opprational2[nextidx][0] >= target):
-#                     indop = nextidx
-#                 else:
-#                     break
-
-#             if(state.step <= 50):
-#                 if(self.ufun(self._best) >= self.ufun.reserved_value):
-#                     outcome = self._best
-#                 else:
-#                     outcome = self.nasho
-#                 # if(self.ufun(self._nasho) >= self.ufun(self._best))
-                
-                
-#             else:
-#                 if(nash):
-#                     outcome = self.nasho
-#                     if(self.ufun(self._best) >= self.ufun.reserved_value):
-#                         if(self.ufun(self._best) <= self.ufun(outcome4)):
-#                             outcome = outcome4
-#                         else:
-#                             outcome = self._best
-#                         # if(len(self.opponent_utilities) == len(self.my_utilities)):
-#                         if(self.opponent_utilities[-1] < self.opponent_utilities[-2]):
-#                             outcome = self.nasho
-#                 else:
-#                     # print("nothing")
-#                     if(self.ufun(self._best) >= self.ufun.reserved_value):
-#                         outcome = self._best
-#                         if(self.ufun(self._best) <= self.ufun(outcome4)):
-#                             outcome = outcome4
-#                     else:
-#                         outcome = self._opprational[self.nidx][2]
-#                         outcome = outcome4
-
-#             # if(self.ufun(self._best) > self.ufun.reserved_value):
-#             #     outcome = self._best
-#         else:
-#             outcome = self.ufun.best()
-#             border = self.ufun.reserved_value
-#             border = self.y2
-#             if(nash):
-#                 border = max(border,self.ufun(self.nasho))
-#             if(self.mode==1):
-#                 myasp = aspiration_function(state.relative_time, 1.0, border, self.fe)
-#                 indmy = max_rational
-#                 while(indmy!=0):
-#                     nextidx = max(indmy-1 , 0)
-#                     if(self._rational[nextidx][0] >= myasp):
-#                         indmy = nextidx
-#                     else:
-#                         break
-                
-#                 indx = indmy
-#                 outcome = self._rational[indx][-1]
-
-#         self.my_utilities.append(self.ufun(outcome))
-#         return SAOResponse(ResponseType.REJECT_OFFER, outcome)
-#         # return SAOResponse(ResponseType.REJECT_OFFER, self.ufun.best())
-
-#     def is_acceptable(self, state: SAOState) -> bool:
-#         # The acceptance strategy
-#         assert self.ufun and self.opponent_ufun
-#         # get the offer from the mechanism state
-#         offer = state.current_offer
-#         # If there is no offer, there is nothing to accept
-#         if offer is None:
-#             return False
-#         if((state.step)==0):
-#             one_step = 0.0001
-#         else:
-#             one_step = (state.relative_time) / (state.step)
-        
-        
-#         if self._best is None:
-#             self._best = offer
-#         else:
-#             if(self.ufun(offer) > self.ufun(self._best)):
-#                 self._best = offer
-#             elif(self.ufun(offer) == self.ufun(self._best)):
-#                 if(self.opponent_ufun(offer) < self.opponent_ufun(self._best)):
-#                     self._best = offer
-
-#         self.opponent_times.append(state.relative_time)
-#         self.opponent_utilities.append(self.opponent_ufun(offer))
-                    
-#         # Find the current aspiration level
-#         myasp = aspiration_function(
-#             state.relative_time, 1.0, self.ufun.reserved_value, self.e
-#         )
-#         opasp = aspiration_function(
-#             state.relative_time, 1.0, self.opponent_ufun.reserved_value, self.e
-#         )
-#         ans = False
-
-#         pat = self.pat * self.lasttime
-#         border = self.ufun.reserved_value
-#         if(state.relative_time >= pat):
-#             myasp = aspiration_function(pat / self.lasttime, 1.0, self.ufun.reserved_value, self.fe)
-#             ratio = (myasp - self.ufun.reserved_value) / ((self.lasttime - pat)*(self.lasttime - pat))
-#             xd = (state.relative_time / self.lasttime) - pat
-#             y = myasp - (ratio*xd*xd) 
-#             border = max(border,y)
-#         else:
-#             border = self.ufun.reserved_value
-
-
-
-#         myasp = aspiration_function(state.relative_time, 1.0, border, self.e)
-
-#         if(state.relative_time + 1 * one_step > 1.0):
-#         # if(state.step + 1 == self.nmi.n_steps or state.relative_time + 1 * one_step > 1.0):
-#             # print(self.predict)
-#             if(float(self.ufun(offer)) > self.ufun.reserved_value):
-#                 if(self.opponent_utilities[-1] <= self.opponent_utilities[-2]):
-#                     return True
-#                 # myasp = 0.0
-
-#         # if(self.nmi.n_steps <= 50):
-#         #     if(float(self.ufun(offer)) > self.ufun.reserved_value):
-#         # accept if the utility of the received offer is higher than
-#         # the current aspiration
-
-#         # return ans
-#         return (float(self.ufun(offer)) >= myasp)
-    
-
-# ?代目 2nd2nd
-# class Shochan(SAONegotiator):
-#     """A simple negotiator that uses curve fitting to learn the reserved value.
-
-#     Args:
-#         min_unique_utilities: Number of different offers from the opponent before starting to
-#                               attempt learning their reserved value.
-#         e: The concession exponent used for the agent's offering strategy
-#         stochasticity: The level of stochasticity in the offers.
-#         enable_logging: If given, a log will be stored  for the estimates.
-
-#     Remarks:
-
-#         - Assumes that the opponent is using a time-based offering strategy that offers
-#           the outcome at utility $u(t) = (u_0 - r) - r \\exp(t^e)$ where $u_0$ is the utility of
-#           the first offer (directly read from the opponent ufun), $e$ is an exponent that controls the
-#           concession rate and $r$ is the reserved value we want to learn.
-#         - After it receives offers with enough different utilities, it starts finding the optimal values
-#           for $e$ and $r$.
-#         - When it is time to respond, RVFitter, calculates the set of rational outcomes **for both agents**
-#           based on its knowledge of the opponent ufun (given) and reserved value (learned). It then applies
-#           the same concession curve defined above to concede over an ordered list of these outcomes.
-#         - Is this better than using the same concession curve on the outcome space without even trying to learn
-#           the opponent reserved value? Maybe sometimes but empirical evaluation shows that it is not in general.
-#         - Note that the way we check for availability of enough data for training is based on the uniqueness of
-#           the utility of offers from the opponent (for the opponent). Given that these are real values, this approach
-#           is suspect because of rounding errors. If two outcomes have the same utility they may appear to have different
-#           but very close utilities because or rounding errors (or genuine very small differences). Such differences should
-#           be ignored.
-#         - Note also that we start assuming that the opponent reserved value is 0.0 which means that we are only restricted
-#           with our own reserved values when calculating the rational outcomes. This is the best case scenario for us because
-#           we have MORE negotiation power when the partner has LOWER utility.
-#     """
-#     def __init__(
-#         self,
-#         *args,
-#         min_unique_utilities: int = 10,
-#         e: float = 17.5,
-#         stochasticity: float = 0.1,
-#         enable_logging: bool = False,
-#         nash_factor=0.1,
-#         **kwargs,
-#     ):
-#         super().__init__(*args, **kwargs)
-#         self.min_unique_utilities = min_unique_utilities
-#         self.e = e
-#         self.fe = e
-#         self.stochasticity = stochasticity
-#         # keeps track of times at which the opponent offers
-#         self.opponent_times: list[float] = []
-#         self.my_times: list[float] = []
-#         # keeps track of opponent utilities of its offers
-#         self.opponent_utilities: list[float] = []
-#         # keeps track of the our last estimate of the opponent reserved value
-#         self._past_oppnent_rv = 0.0
-#         # keeps track of the rational outcome set given our estimate of the
-#         # opponent reserved value and our knowledge of ours
-#         self._rational: list[tuple[float, float, Outcome]] = []
-#         self._enable_logging = enable_logging
-#         self.preoffer = []
-#         self.predict = []
-
-#         self._outcomes: list[Outcome] = []
-#         self._min_acceptable = float("inf")
-#         self._nash_factor = nash_factor
-#         self._best: Outcome = None  # type: ignore
-#         self.nidx = 0
-#         self.opponent_ufun.reserved_value = 0.0
-#         self.lasttime = 1.0
-#         self.diffmean = 0.01
-#         self.pat = 0.95
-#         self.g1 = 0
-#         self.g2 = 0
-#         self.g3 = 0
-#         self.g4 = 0
-#         self.mode = 0
-#         # self.opmin = 1.0
-#         # self.most
-        
-
-#     def __call__(self, state: SAOState) -> SAOResponse:
-#         assert self.ufun and self.opponent_ufun
-#         # update the opponent reserved value in self.opponent_ufun
-#         # self.update_reserved_value(state)
-#         # rune the acceptance strategy and if the offer received is acceptable, accept it
-#         diff = []
-#         for i in range(len(self.opponent_times)):
-#             diff.append(self.opponent_times[i] - self.my_times[i])
-#         # diff = self.opponent_times - self.my_times
-#         if(len(diff)==0):
-#             diff_mean=0.01
-#         else:
-#             diff_mean = sum(diff) / len(diff)
-        
-#         self.diff_mean = diff_mean
-
-#         asp = aspiration_function(state.relative_time / self.lasttime, 1.0, self.ufun.reserved_value, self.fe)
-        
-#         self.e = self.fe + (1.0 - asp) * 100
-
-#         self.my_times.append(state.relative_time)
-#         if self.is_acceptable(state):
-#             # print(self.predict)
-#             # print(self.ufun(state.current_offer))
-#             # print(self.opponent_ufun(state.current_offer))
-#             # print(self.opponent_ufun.reserved_value)
-#             # print(len(self.my_times))
-#             if((state.step)==0):
-#                 one_step = 0.0001
-#             else:
-#                 one_step = (state.relative_time) / (state.step)
-#             # print(state.step)
-#             # print(one_step)
-#             # print(self.my_times)
-#             # print(self.my_times[-1])
-#             # print(len(self.opponent_times))
-#             # print(self.opponent_times)
-#             # print(self.opponent_utilities)
-#             # print(self.opponent_times[-1])
-#             # print(state.step)
-#             # # print(state.time)
-#             # print(state.relative_time)
-#             # print(diff_mean)
-#             # print(self.nmi.n_step)
-#             return SAOResponse(ResponseType.ACCEPT_OFFER, state.current_offer)
-#         else:
-#             self.preoffer.append((self.ufun(state.current_offer),self.opponent_ufun(state.current_offer)))
-#         # The offering strategy
-#         # nash
-#         ufuns = (self.ufun, self.opponent_ufun)
-#         if((state.step)==0):
-#             one_step = 0.0001
-#         else:
-#             one_step = (state.relative_time) / (state.step)
-#         lasttime = (1.0 // one_step) * one_step
-#         self.lasttime = lasttime
-#         # The offering strategy
-            
-#         # nash
-#         ufuns = (self.ufun, self.opponent_ufun)
-#         # list all outcomes
-#         outcomes = list(self.ufun.outcome_space.enumerate_or_sample())
-#         # find the pareto-front and the nash point
-#         frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)
-#         frontier_outcomes = [outcomes[_] for _ in frontier_indices]
-#         my_frontier_utils = [_[0] for _ in frontier_utils]
-#         opp_frontier_utils = [_[1] for _ in frontier_utils]
-#         # print(my_frontier_utils)
-#         nash = nash_points(ufuns, frontier_utils)  # type: ignore
-#         if nash:
-#             # find my utility at the Nash Bargaining Solution.
-#             # print(nash)
-#             self.nash = nash[0][0][0]
-#             self.nasho = frontier_outcomes[nash[0][1]]
-#             # print(self.ufun(self.nasho))
-#             # print(self.opponent_ufun(self.nasho))
-
-#         else:
-#             self.nash = 0.5 * (float(self.ufun.max()) + self.ufun.reserved_value)
-#         # Set the acceptable utility limit
-#         # self._min_acceptable = my_nash_utility * self._nash_factor
-#         self._min_acceptable = self.ufun.reserved_value
-#         # self._min_acceptable = 0
-#         # Set the set of outcomes to offer from
-#         # self._outcomes = [
-#         #     w
-#         #     for u, w in zip(my_frontier_utils, frontier_outcomes)
-#         #     if u >= self._min_acceptable
-#         # ]        
-    
-#         # We only update our estimate of the rational list of outcomes if it is not set or
-#         # there is a change in estimated reserved value
-#         if (
-#             not self._rational
-#             # or abs(self.opponent_ufun.reserved_value - self._past_oppnent_rv) > 1e-3
-#         ):
-#             # The rational set of outcomes sorted dependingly according to our utility function
-#             # and the opponent utility function (in that order).
-#             # self._rational = sorted(
-#             #     [
-#             #         (my_util, opp_util, _)
-#             #         for _ in self.nmi.outcome_space.enumerate_or_sample(
-#             #             levels=10, max_cardinality=100_000
-#             #         )
-#             #         if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#             #         and (opp_util := float(self.opponent_ufun(_)))
-#             #         > self.opponent_ufun.reserved_value
-#             #     ],
-#             # )
-#             ave_nash = 1.0
-#             if(len(my_frontier_utils)!=0):
-#                 ave_nash = 0.0
-#                 min_nash = my_frontier_utils[0]+ opp_frontier_utils[0]
-#                 for i in frontier_utils:
-#                     ave_nash = ave_nash + i[0] + i[1]
-#                     if(min_nash > i[0] + i[1]):
-#                         # print(min_nash)
-#                         # print(i[0] + i[1])
-#                         min_nash = i[0] + i[1]
-#                 ave_nash = ave_nash / len(my_frontier_utils)
-                
-#                 # print(min_nash)
-
-
-#             self._outcomes = [
-#                 w
-#                 for u, w in zip(my_frontier_utils, frontier_outcomes)
-#                 if u >= self.ufun.reserved_value
-#             ]     
-#             self._outcomes2 = [
-#                 w
-#                 for u, w in zip(my_frontier_utils, frontier_outcomes)
-#             ]     
-
-#             # if(len(my_frontier_utils)!=0):
-#             #     for _ in outcomes:
-#             #         if (float(self.ufun(_)) + float(self.opponent_ufun(_)) >= min_nash):
-#             #             if( _ not in self._outcomes):
-#             #                 self._outcomes.append(_)
-
-#             # if(len(my_frontier_utils)!=0):
-#             #     for _ in outcomes:
-#             #         if (float(self.ufun(_)) + float(self.opponent_ufun(_)) >= 1.0):
-#             #             if( _ not in self._outcomes):
-#             #                 self._outcomes.append(_)
-            
-#                     # if (float(self.ufun(_)) + float(self.opponent_ufun(_)) >= ave_nash - 0.1):
-#                     #     if( _ not in self._outcomes):
-#                     #         self._outcomes.append(_)
-
-
-#             # self._rational = sorted(
-#             #     [
-#             #         (my_util, opp_util, _)
-#             #         for _ in self._outcomes
-#             #         if (my_util := float(self.ufun(_))) > 0
-#             #         and (opp_util := float(self.opponent_ufun(_)))
-#             #         > 0
-#             #     ],
-#             # )
-#             self._rational = sorted(
-#                 [
-#                     (my_util, opp_util, _)
-#                     for _ in self._outcomes
-#                     if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#                     and (opp_util := float(self.opponent_ufun(_)))
-#                     > 0
-#                 ],
-#             )
-#             self.nidx = len(self._rational)-1
-
-#             self._opprational = sorted(
-#                 [
-#                     (opp_util, my_util, _)
-#                     for _ in self._outcomes
-#                     if (my_util := float(self.ufun(_))) > 0
-#                     # if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#                     and (opp_util := float(self.opponent_ufun(_)))
-#                     > 0
-#                 ],
-#             )
-
-#             # ufuns = (self.ufun, self.opponent_ufun)
-#             # print(self.ufun)
-#             # print(self.opponent_ufun)
-#             self._rational2 = sorted(
-#                 [
-#                     (my_util, opp_util, _)
-#                     for _ in outcomes
-#                     if (my_util := float(self.ufun(_))) > 0
-#                     and (opp_util := float(self.opponent_ufun(_)))
-#                     > 0
-#                 ],
-#             )
-#             self.nidx = len(self._rational)-1
-
-#             self._opprational2 = sorted(
-#                 [
-#                     (opp_util, my_util, _)
-#                     for _ in outcomes
-#                     if (my_util := float(self.ufun(_))) > 0
-#                     # if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#                     and (opp_util := float(self.opponent_ufun(_)))
-#                     > 0
-#                 ],
-#             )
-
-#             y1 = self._rational2[-1][0]
-#             x1 = self._rational2[-1][1]
-#             y2 = self._opprational2[-1][1]
-#             x2 = self._opprational2[-1][0]
-#             difx = x2 - x1
-#             dify = y1 - y2
-#             if(difx - dify >= 0.2):
-#                 self.mode = 1
-#             # print(self.mode)
-#             x1 = int(x1*100)/100
-#             x2 = int(x2*100)/100
-#             y1 = int(y1*100)/100
-#             y2 = int(y2*100)/100
-
-#             # print(len(self._outcomes))
-#             # print([x1,y1])
-#             # print([x2,y2])
-
-#             # for o in outcomes:
-#             #     x = float(self.ufun(o))
-#             #     x = int(self.ufun(o)*100)/100
-#             #     y = float(self.opponent_ufun(o))
-#             #     y = int(self.opponent_ufun(o)*100)/100
-#             #     tmp1 = (x - x1) * (y1 - y2)
-#             #     tmp2 = (y - y2) * (x2 - x1)
-#             #     if(tmp1 > tmp2):
-#             #         tmp3 = (x2 - x) * (y1 - y2)
-#             #         tmp4 = (y - y2) * (x2 - x1)
-#             #         if(tmp3 < tmp4):
-#             #             self.g1 = self.g1 + 1
-#             #         elif(tmp3 > tmp4):
-#             #             self.g2 = self.g2 + 1
-#             #     elif(tmp1 < tmp2):
-#             #         tmp3 = (x2 - x) * (y1 - y2)
-#             #         tmp4 = (y - y2) * (x2 - x1)
-#             #         if(tmp3 < tmp4):
-#             #             self.g4 = self.g4 + 1
-#             #         elif(tmp3 > tmp4):
-#             #             self.g3 = self.g3 + 1
-
-#             # print([self.g1,self.g2,self.g3,self.g4])
-
-
-        
-#             # print(self.nidx)
-#         # If there are no rational outcomes (i.e. our estimate of the opponent rv is very wrogn),
-#         # then just revert to offering our top offer
-#         max_rational = len(self._rational) - 1
-#         if not self._rational:
-#             return SAOResponse(ResponseType.REJECT_OFFER, self.ufun.best())
-        
-
-#         # find our aspiration level (value between 0 and 1) the higher the higher utility we require
-#         asp = aspiration_function(state.relative_time, 1.0, 0.0, self.e)
-#         # find the index of the rational outcome at the aspiration level (in the rational set of outcomes)
-#         n_rational = len(self._rational)
-#         max_rational = n_rational - 1
-#         # min_indx = max(0, min(max_rational, int(asp * max_rational)))
-
-#         # asp = aspiration_function(state.relative_time, 1.0, self.ufun.reserved_value, self.e)
-#         # while(self.nidx!=0):
-#         #     nextidx = max(self.nidx-1 , 0)
-#         #     if(self._rational[nextidx][0] > asp):
-#         #         self.nidx = nextidx
-#         #     else:
-#         #         break
-
-#         # min_indx = self.nidx
-        
-#         # pat = 0.95
-#         # pat = self.pat * self.lasttime
-#         border = self.ufun.reserved_value
-#         # if(state.relative_time >= pat):
-#         #     myasp = aspiration_function(pat / self.lasttime, 1.0, self.ufun.reserved_value, self.fe)
-#         #     ratio = (myasp - self.ufun.reserved_value) / ((self.lasttime - pat)*(self.lasttime - pat))
-#         #     xd = (state.relative_time / self.lasttime) - pat
-#         #     y = myasp - (ratio*xd*xd) 
-#         #     # y = aspiration_function(xd,self.lasttime - xd, myasp, self.ufun.reserved_value, self.e)
-#         #     # myasp = y
-#         #     border = max(border,y)
-#         #     # asp = aspiration_function(state.relative_time, 1.0, rv, self.e)
-#         #     # indmy = max_rational
-#         #     # while(self.nidx!=0):
-#         #     #     nextidx = max(indmy-1 , 0)
-#         #     #     if(self._rational[nextidx][0] >= y):
-#         #     #         indmy = nextidx
-#         #     #     else:
-#         #     #         break
-#         #     # outcome = self._best
-#         # else:
-#         #     # tmp = 0.0
-#         #     if(state.relative_time > 1.1):
-#         #         popt, pcov = curve_fit(aspiration_function, self.opponent_times, self.opponent_utilities,bounds=(0, [1.0, 1.0, 1000.0]))
-#         #         tmp = popt[1]
-#         #         # print(state.relative_time)
-#         #         # print(popt)
-#         #         indop = len(self._opprational) - 1 
-#         #         while(indop!=0):
-#         #             nextidx = max(indop-1, 0)
-#         #             if(self._opprational[nextidx][0] >= tmp):
-#         #                 indop = nextidx
-#         #             else:
-#         #                 break
-
-#         #         pre_rv = self._opprational[self.nidx][1]
-
-#         #         # self.opponent_ufun.reserved_value = pre_rv
-#         #         border = max(border,pre_rv)
-#         #     else:
-#         #         border = self.ufun.reserved_value
-
-#             # myasp = aspiration_function(state.relative_time, 1.0, rv, self.e)
-#             # indmy = max_rational
-#             # while(self.nidx!=0):
-#             #     nextidx = max(indmy-1 , 0)
-#             #     if(self._rational[nextidx][0] >= myasp):
-#             #         indmy = nextidx
-#             #     else:
-#             #         break
-
-
-#         myasp = aspiration_function(state.relative_time, 1.0, border, self.fe)
-
-#         # if(state.step < 25):
-#         #     myasp = aspiration_function(state.relative_time, 1.0, border, 5.0)
-#         # elif(state.step < 75):
-#         #     myasp = aspiration_function(state.relative_time, 1.0, border, 7.5)
-#         # elif(state.step < 150):
-#         #     myasp = aspiration_function(state.relative_time, 1.0, border, 10)
-#         # else:
-#         #     myasp = aspiration_function(state.relative_time, 1.0, border, self.fe)
-
-
-#         # myasp = aspiration_function(state.relative_time, 1.0, border, self.e)
-
-
-#         # indmy = max_rational
-#         # while(indmy!=0):
-#         #     nextidx = max(indmy-1 , 0)
-#         #     if(self._rational[nextidx][0] >= myasp):
-#         #         indmy = nextidx
-#         #     else:
-#         #         break
-        
-#         # indx = indmy
-#         # outcome = self._rational[indx][-1]
-
-
-
-#         myut = self.nash
-#         myut = self.ufun.reserved_value + 0.1
-#         # myut = self.ufun.reserved_value 
-#         if(state.relative_time + 2 * one_step > 1.0):
-#             opmin = sorted(self.opponent_utilities)[0]
-#             # print("-----------------------")
-#             # print(opmin)
-#             indop = len(self._opprational) - 1 
-#             while(indop!=0):
-#                 if(myut <= self._opprational[indop][1]):
-#                     myut = self._opprational[indop][1]
-#                     outcome = self._opprational[indop][2]
-#                 nextidx = max(indop-1, 0)
-#                 if(self._opprational[nextidx][0] >= opmin):
-#                     indop = nextidx
-#                 else:
-#                     break
-
-#             pre_rv = self._opprational[self.nidx][1]
-#             # print(pre_rv)
-
-#             # self.opponent_ufun.reserved_value = pre_rv
-#             border = max(border,pre_rv)
-#             if(state.step <= 50):
-#                 if(self.ufun(self._best) >= self.ufun.reserved_value):
-#                     outcome = self._best
-#                 else:
-#                     outcome = self.nasho
-#                 # if(self.ufun(self._nasho) >= self.ufun(self._best))
-                
-                
-#             else:
-#                 if(nash):
-#                     outcome = self.nasho
-#                     if(self.ufun(self._best) >= self.ufun(self.nasho)):
-#                         outcome = self._best
-#                 else:
-#                     # print("nothing")
-#                     if(self.ufun(self._best) >= self.ufun.reserved_value):
-#                         outcome = self._best
-#                     else:
-#                         outcome = self._opprational[self.nidx][2]
-#             # print(self.ufun(outcome))
-#             # print(self.opponent_ufun(outcome))
-#             # print(self.predict)
-#             # if(self.ufun(self._best) > self.ufun.reserved_value):
-#             #     outcome = self._best
-#         else:
-#             outcome = self.ufun.best()
-#             border = self.ufun.reserved_value
-#             if(self.mode==1):
-#                 myasp = aspiration_function(state.relative_time, 1.0, border, self.fe)
-#                 indmy = max_rational
-#                 while(indmy!=0):
-#                     nextidx = max(indmy-1 , 0)
-#                     if(self._rational[nextidx][0] >= myasp):
-#                         indmy = nextidx
-#                     else:
-#                         break
-                
-#                 indx = indmy
-#                 outcome = self._rational[indx][-1]
-            
-#         return SAOResponse(ResponseType.REJECT_OFFER, outcome)
-#         # return SAOResponse(ResponseType.REJECT_OFFER, self.ufun.best())
-
-#     def is_acceptable(self, state: SAOState) -> bool:
-#         # The acceptance strategy
-#         assert self.ufun and self.opponent_ufun
-#         # get the offer from the mechanism state
-#         offer = state.current_offer
-#         # If there is no offer, there is nothing to accept
-#         if offer is None:
-#             return False
-#         if((state.step)==0):
-#             one_step = 0.0001
-#         else:
-#             one_step = (state.relative_time) / (state.step)
-        
-#         # print("offer")
-#         # print(offer)
-#         # print(negmas.outcomes.outcome2dict(offer))
-        
-#         if self._best is None:
-#             self._best = offer
-#         else:
-#             if(self.ufun(offer) > self.ufun(self._best)):
-#                 # print(self.ufun(offer))
-#                 # print(self.ufun(self._best))
-#                 self._best = offer
-#             elif(self.ufun(offer) == self.ufun(self._best)):
-#                 if(self.opponent_ufun(offer) < self.opponent_ufun(self._best)):
-#                     self._best = offer
-
-#         # print(offer)
-
-#         self.opponent_times.append(state.relative_time)
-#         self.opponent_utilities.append(self.opponent_ufun(offer))
-                    
-#         # Find the current aspiration level
-#         myasp = aspiration_function(
-#             state.relative_time, 1.0, self.ufun.reserved_value, self.e
-#         )
-#         opasp = aspiration_function(
-#             state.relative_time, 1.0, self.opponent_ufun.reserved_value, self.e
-#         )
-#         ans = False
-
-#         pat = self.pat * self.lasttime
-#         border = self.ufun.reserved_value
-#         if(state.relative_time >= pat):
-#             myasp = aspiration_function(pat / self.lasttime, 1.0, self.ufun.reserved_value, self.fe)
-#             ratio = (myasp - self.ufun.reserved_value) / ((self.lasttime - pat)*(self.lasttime - pat))
-#             xd = (state.relative_time / self.lasttime) - pat
-#             y = myasp - (ratio*xd*xd) 
-#             border = max(border,y)
-
-#             # asp = aspiration_function(state.relative_time, 1.0, rv, self.e)
-#             # indmy = max_rational
-#             # while(self.nidx!=0):
-#             #     nextidx = max(indmy-1 , 0)
-#             #     if(self._rational[nextidx][0] >= y):
-#             #         indmy = nextidx
-#             #     else:
-#             #         break
-#             # outcome = self._best
-#         else:
-#             # tmp = 0.0
-#             if(state.relative_time > 1.1):
-#                 popt, pcov = curve_fit(aspiration_function, self.opponent_times, self.opponent_utilities,bounds=(0, [1.0, 1.0, 1000.0]))
-#                 tmp = popt[1]
-#                 # print(state.relative_time)
-#                 # print(popt)
-#                 indop = len(self._opprational) - 1 
-#                 while(indop!=0):
-#                     nextidx = max(indop-1, 0)
-#                     if(self._opprational[nextidx][0] >= tmp):
-#                         indop = nextidx
-#                     else:
-#                         break
-
-#                 pre_rv = self._opprational[self.nidx][1]
-
-#                 # self.opponent_ufun.reserved_value = pre_rv
-#                 border = max(border,pre_rv)
-#             else:
-#                 border = self.ufun.reserved_value
-
-#             # myasp = aspiration_function(state.relative_time, 1.0, rv, self.e)
-#             # indmy = max_rational
-#             # while(self.nidx!=0):
-#             #     nextidx = max(indmy-1 , 0)
-#             #     if(self._rational[nextidx][0] >= myasp):
-#             #         indmy = nextidx
-#             #     else:
-#             #         break
-
-
-#         myasp = aspiration_function(state.relative_time, 1.0, border, self.e)
-
-#         # if(state.step < 25):
-#         #     myasp = aspiration_function(state.relative_time, 1.0, border, 5.0)
-#         # elif(state.step < 75):
-#         #     myasp = aspiration_function(state.relative_time, 1.0, border, 7.5)
-#         # elif(state.step < 150):
-#         #     myasp = aspiration_function(state.relative_time, 1.0, border, 10)
-#         # else:
-#         #     myasp = aspiration_function(state.relative_time, 1.0, border, self.fe)
-
-#         # myasp = aspiration_function(state.relative_time, 1.0, border, self.e)
-
-
-#         # if(state.relative_time >= 0.97):
-#         #     ans = (float(self.ufun(offer)) >= myasp)
-#         # else:
-#         #     asp = max(myasp,opasp)
-#         #     ans = (float(self.ufun(offer)) >= asp)
-
-#         if(state.relative_time + one_step > 1.0):
-#             # print(self.predict)
-#             if(float(self.ufun(offer)) > self.ufun.reserved_value):
-#                 if(self.opponent_utilities[-1] <= self.opponent_utilities[-2]):
-#                     return True
-#                 # myasp = 0.0
-
-
-#         # accept if the utility of the received offer is higher than
-#         # the current aspiration
-
-#         # return ans
-#         return (float(self.ufun(offer)) >= myasp)
-
-
-# ?代目
-# class Shochan(SAONegotiator):
-#     """A simple negotiator that uses curve fitting to learn the reserved value.
-
-#     Args:
-#         min_unique_utilities: Number of different offers from the opponent before starting to
-#                               attempt learning their reserved value.
-#         e: The concession exponent used for the agent's offering strategy
-#         stochasticity: The level of stochasticity in the offers.
-#         enable_logging: If given, a log will be stored  for the estimates.
-
-#     Remarks:
-
-#         - Assumes that the opponent is using a time-based offering strategy that offers
-#           the outcome at utility $u(t) = (u_0 - r) - r \\exp(t^e)$ where $u_0$ is the utility of
-#           the first offer (directly read from the opponent ufun), $e$ is an exponent that controls the
-#           concession rate and $r$ is the reserved value we want to learn.
-#         - After it receives offers with enough different utilities, it starts finding the optimal values
-#           for $e$ and $r$.
-#         - When it is time to respond, RVFitter, calculates the set of rational outcomes **for both agents**
-#           based on its knowledge of the opponent ufun (given) and reserved value (learned). It then applies
-#           the same concession curve defined above to concede over an ordered list of these outcomes.
-#         - Is this better than using the same concession curve on the outcome space without even trying to learn
-#           the opponent reserved value? Maybe sometimes but empirical evaluation shows that it is not in general.
-#         - Note that the way we check for availability of enough data for training is based on the uniqueness of
-#           the utility of offers from the opponent (for the opponent). Given that these are real values, this approach
-#           is suspect because of rounding errors. If two outcomes have the same utility they may appear to have different
-#           but very close utilities because or rounding errors (or genuine very small differences). Such differences should
-#           be ignored.
-#         - Note also that we start assuming that the opponent reserved value is 0.0 which means that we are only restricted
-#           with our own reserved values when calculating the rational outcomes. This is the best case scenario for us because
-#           we have MORE negotiation power when the partner has LOWER utility.
-#     """
-#     def __init__(
-#         self,
-#         *args,
-#         min_unique_utilities: int = 10,
-#         e: float = 17.5,
-#         stochasticity: float = 0.1,
-#         enable_logging: bool = False,
-#         nash_factor=0.1,
-#         **kwargs,
-#     ):
-#         super().__init__(*args, **kwargs)
-#         self.min_unique_utilities = min_unique_utilities
-#         self.e = e
-#         self.fe = e
-#         self.stochasticity = stochasticity
-#         # keeps track of times at which the opponent offers
-#         self.opponent_times: list[float] = []
-#         self.my_times: list[float] = []
-#         # keeps track of opponent utilities of its offers
-#         self.opponent_utilities: list[float] = []
-#         # keeps track of the our last estimate of the opponent reserved value
-#         self._past_oppnent_rv = 0.0
-#         # keeps track of the rational outcome set given our estimate of the
-#         # opponent reserved value and our knowledge of ours
-#         self._rational: list[tuple[float, float, Outcome]] = []
-#         self._enable_logging = enable_logging
-#         self.preoffer = []
-#         self.predict = []
-
-#         self._outcomes: list[Outcome] = []
-#         self._min_acceptable = float("inf")
-#         self._nash_factor = nash_factor
-#         self._best: Outcome = None  # type: ignore
-#         self.nidx = 0
-#         self.opponent_ufun.reserved_value = 0.0
-#         self.lasttime = 1.0
-#         self.diffmean = 0.01
-#         self.pat = 0.95
-#         self.nash = 0.5
-#         self.nasho: Outcome = None
-#         # self.opmin = 1.0
-#         # self.most
-        
-
-#     def __call__(self, state: SAOState) -> SAOResponse:
-#         assert self.ufun and self.opponent_ufun
-#         # update the opponent reserved value in self.opponent_ufun
-#         # self.update_reserved_value(state)
-#         # rune the acceptance strategy and if the offer received is acceptable, accept it
-#         diff = []
-#         for i in range(len(self.opponent_times)):
-#             diff.append(self.opponent_times[i] - self.my_times[i])
-#         # diff = self.opponent_times - self.my_times
-#         if(len(diff)==0):
-#             diff_mean=0.01
-#         else:
-#             diff_mean = sum(diff) / len(diff)
-        
-#         self.diff_mean = diff_mean
-
-#         asp = aspiration_function(state.relative_time / self.lasttime, 1.0, self.ufun.reserved_value, self.fe)
-        
-#         self.e = self.fe + (1.0 - asp) * 100
-
-#         self.my_times.append(state.relative_time)
-
-#         # if(state.timedout):
-#         #     print(state.relative_time)
-
-#         # if(state.started):
-#         #     print("###")
-#         #     print(state.last_negotiator)
-#         #     print("##")
-
-#         if self.is_acceptable(state):
-#             # print(self.predict)
-#             # print(self.ufun(state.current_offer))
-#             # print(self.opponent_ufun(state.current_offer))
-#             # print(self.opponent_ufun.reserved_value)
-#             # print(len(self.my_times))
-#             if((state.step)==0):
-#                 one_step = 0.0001
-#             else:
-#                 # one_step = (state.relative_time) / (state.step)
-#                 one_step = (self.my_times[-1] - self.my_times[1]) / (state.step - 1)
-#                 # one_step3 = (self.my_times[-1] - self.my_times[0]) / (state.step)
-#             # print(state.step)
-#             # print(state.relative_time)
-#             # print(state.timedout)
-#             # print(self.my_times[1])
-#             # print(self.my_times[0])
-#             # print(one_step)
-#             # print(one_step2)
-#             # print(one_step3)
-
-#             # print(self.my_times)
-#             # print(self.my_times[-1])
-#             # print(len(self.opponent_times))
-#             # print(self.opponent_times)
-#             # print(self.opponent_utilities)
-#             # print(self.opponent_times[-1])
-#             # print(state.step)
-#             # # print(state.time)
-#             # print(state.relative_time)
-#             # print(diff_mean)
-#             # print(state.current_proposer)
-#             # print(state.last_negotiator)
-#             # print(state.started)
-
-#             return SAOResponse(ResponseType.ACCEPT_OFFER, state.current_offer)
-#         else:
-#             self.preoffer.append((self.ufun(state.current_offer),self.opponent_ufun(state.current_offer)))
-#         # The offering strategy
-#         # nash
-#         ufuns = (self.ufun, self.opponent_ufun)
-#         if((state.step)==0 or (state.step)==1):
-#             one_step = 0.0001
-#         else:
-#             one_step = (state.relative_time) / (state.step)
-#             one_step = (self.my_times[-1] - self.my_times[1]) / (state.step - 1)
-#         lasttime = (1.0 // one_step) * one_step
-#         self.lasttime = lasttime
-#         # The offering strategy
-            
-#         # nash
-#         ufuns = (self.ufun, self.opponent_ufun)
-#         # list all outcomes
-#         outcomes = list(self.ufun.outcome_space.enumerate_or_sample())
-#         # find the pareto-front and the nash point
-#         frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)
-#         frontier_outcomes = [outcomes[_] for _ in frontier_indices]
-#         my_frontier_utils = [_[0] for _ in frontier_utils]
-#         opp_frontier_utils = [_[1] for _ in frontier_utils]
-#         # print(my_frontier_utils)
-#         nash = nash_points(ufuns, frontier_utils)  # type: ignore
-#         if nash:
-#             # find my utility at the Nash Bargaining Solution.
-#             # print(nash)
-#             self.nash = nash[0][0][0]
-#             # print("333")
-#             # print(self.nash)
-#             # print(nash)
-#             # # print(nash[0])
-#             # # print(nash[0][0])
-#             # # print(nash[0][0][0])
-#             # print(nash[0][1])
-#             # print(outcomes[nash[0][1]])
-#             # print("33")
-#             self.nasho = outcomes[nash[0][1]]
-#         else:
-#             self.nash = 0.5 * (float(self.ufun.max()) + self.ufun.reserved_value)
-#         # Set the acceptable utility limit
-#         self._min_acceptable = self.nash * self._nash_factor
-#         self._min_acceptable = self.ufun.reserved_value
-#         # self._min_acceptable = 0
-#         # Set the set of outcomes to offer from
-#         # self._outcomes = [
-#         #     w
-#         #     for u, w in zip(my_frontier_utils, frontier_outcomes)
-#         #     if u >= self._min_acceptable
-#         # ]        
-    
-#         # We only update our estimate of the rational list of outcomes if it is not set or
-#         # there is a change in estimated reserved value
-#         if (
-#             not self._rational
-#             # or abs(self.opponent_ufun.reserved_value - self._past_oppnent_rv) > 1e-3
-#         ):
-#             # The rational set of outcomes sorted dependingly according to our utility function
-#             # and the opponent utility function (in that order).
-#             # self._rational = sorted(
-#             #     [
-#             #         (my_util, opp_util, _)
-#             #         for _ in self.nmi.outcome_space.enumerate_or_sample(
-#             #             levels=10, max_cardinality=100_000
-#             #         )
-#             #         if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#             #         and (opp_util := float(self.opponent_ufun(_)))
-#             #         > self.opponent_ufun.reserved_value
-#             #     ],
-#             # )
-#             ave_nash = 1.0
-#             if(len(my_frontier_utils)!=0):
-#                 ave_nash = 0.0
-#                 min_nash = my_frontier_utils[0]+ opp_frontier_utils[0]
-#                 for i in frontier_utils:
-#                     ave_nash = ave_nash + i[0] + i[1]
-#                     if(min_nash > i[0] + i[1]):
-#                         # print(min_nash)
-#                         # print(i[0] + i[1])
-#                         min_nash = i[0] + i[1]
-#                 ave_nash = ave_nash / len(my_frontier_utils)
-#                 # print(min_nash)
-
-
-#             self._outcomes = [
-#                 w
-#                 for u, w in zip(my_frontier_utils, frontier_outcomes)
-#                 if u >= self.ufun.reserved_value
-#             ]     
-
-#             # if(len(my_frontier_utils)!=0):
-#             #     for _ in outcomes:
-#             #         if (float(self.ufun(_)) + float(self.opponent_ufun(_)) >= min_nash):
-#             #             if( _ not in self._outcomes):
-#             #                 self._outcomes.append(_)
-
-#             # if(len(my_frontier_utils)!=0):
-#             #     for _ in outcomes:
-#             #         if (float(self.ufun(_)) + float(self.opponent_ufun(_)) >= 1.0):
-#             #             if( _ not in self._outcomes):
-#             #                 self._outcomes.append(_)
-            
-#                     # if (float(self.ufun(_)) + float(self.opponent_ufun(_)) >= ave_nash - 0.1):
-#                     #     if( _ not in self._outcomes):
-#                     #         self._outcomes.append(_)
-
-
-#             # self._rational = sorted(
-#             #     [
-#             #         (my_util, opp_util, _)
-#             #         for _ in self._outcomes
-#             #         if (my_util := float(self.ufun(_))) > 0
-#             #         and (opp_util := float(self.opponent_ufun(_)))
-#             #         > 0
-#             #     ],
-#             # )
-#             self._rational = sorted(
-#                 [
-#                     (my_util, opp_util, _)
-#                     for _ in self._outcomes
-#                     if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#                     and (opp_util := float(self.opponent_ufun(_)))
-#                     > 0
-#                 ],
-#             )
-#             self.nidx = len(self._rational)-1
-
-#             self._opprational = sorted(
-#                 [
-#                     (opp_util, my_util, _)
-#                     for _ in self._outcomes
-#                     if (my_util := float(self.ufun(_))) > 0
-#                     # if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#                     and (opp_util := float(self.opponent_ufun(_)))
-#                     > 0
-#                 ],
-#             )
-#             # print(self.nidx)
-#         # If there are no rational outcomes (i.e. our estimate of the opponent rv is very wrogn),
-#         # then just revert to offering our top offer
-#         max_rational = len(self._rational) - 1
-#         if not self._rational:
-#             return SAOResponse(ResponseType.REJECT_OFFER, self.ufun.best())
-        
-
-#         # find our aspiration level (value between 0 and 1) the higher the higher utility we require
-#         asp = aspiration_function(state.relative_time, 1.0, 0.0, self.e)
-#         # find the index of the rational outcome at the aspiration level (in the rational set of outcomes)
-#         n_rational = len(self._rational)
-#         max_rational = n_rational - 1
-#         # min_indx = max(0, min(max_rational, int(asp * max_rational)))
-
-#         # asp = aspiration_function(state.relative_time, 1.0, self.ufun.reserved_value, self.e)
-#         # while(self.nidx!=0):
-#         #     nextidx = max(self.nidx-1 , 0)
-#         #     if(self._rational[nextidx][0] > asp):
-#         #         self.nidx = nextidx
-#         #     else:
-#         #         break
-
-#         # min_indx = self.nidx
-        
-#         pat = 0.95
-#         pat = self.pat * self.lasttime
-#         border = self.ufun.reserved_value
-#         if(state.relative_time >= pat):
-#             myasp = aspiration_function(pat / self.lasttime, 1.0, self.ufun.reserved_value, self.fe)
-#             ratio = (myasp - self.ufun.reserved_value) / ((self.lasttime - pat)*(self.lasttime - pat))
-#             xd = (state.relative_time / self.lasttime) - pat
-#             y = myasp - (ratio*xd*xd) 
-#             # y = aspiration_function(xd,self.lasttime - xd, myasp, self.ufun.reserved_value, self.e)
-#             # myasp = y
-#             border = max(border,y)
-#             # asp = aspiration_function(state.relative_time, 1.0, rv, self.e)
-#             # indmy = max_rational
-#             # while(self.nidx!=0):
-#             #     nextidx = max(indmy-1 , 0)
-#             #     if(self._rational[nextidx][0] >= y):
-#             #         indmy = nextidx
-#             #     else:
-#             #         break
-#             # outcome = self._best
-#         else:
-#             # tmp = 0.0
-#             if(state.relative_time > 1.1):
-#                 popt, pcov = curve_fit(aspiration_function, self.opponent_times, self.opponent_utilities,bounds=(0, [1.0, 1.0, 1000.0]))
-#                 tmp = popt[1]
-#                 # print(state.relative_time)
-#                 # print(popt)
-#                 indop = len(self._opprational) - 1 
-#                 while(indop!=0):
-#                     nextidx = max(indop-1, 0)
-#                     if(self._opprational[nextidx][0] >= tmp):
-#                         indop = nextidx
-#                     else:
-#                         break
-
-#                 pre_rv = self._opprational[self.nidx][1]
-
-#                 # self.opponent_ufun.reserved_value = pre_rv
-#                 border = max(border,pre_rv)
-#             else:
-#                 border = self.ufun.reserved_value
-
-#             # myasp = aspiration_function(state.relative_time, 1.0, rv, self.e)
-#             # indmy = max_rational
-#             # while(self.nidx!=0):
-#             #     nextidx = max(indmy-1 , 0)
-#             #     if(self._rational[nextidx][0] >= myasp):
-#             #         indmy = nextidx
-#             #     else:
-#             #         break
-
-
-#         myasp = aspiration_function(state.relative_time, 1.0, border, self.fe)
-#         indmy = max_rational
-#         while(indmy!=0):
-#             nextidx = max(indmy-1 , 0)
-#             if(self._rational[nextidx][0] >= myasp):
-#                 indmy = nextidx
-#             else:
-#                 break
-        
-#         indx = indmy
-#         outcome = self._rational[indx][-1]
-#         myut = self.ufun.reserved_value + 0.15
-#         # print(state.relative_time + 1 * one_step)
-#         if(state.relative_time + 2 * one_step >= 1.0):
-#             opmin = sorted(self.opponent_utilities)[0]
-#             # print("-----------------------")
-#             # print(state.relative_time + 2 * one_step)
-#             # print(state.relative_time)
-#             # print(one_step)
-#             # print(self.lasttime)
-#             # print(opmin)
-#             indop = len(self._opprational) - 1 
-#             while(indop!=0):
-#                 if(myut <= self._opprational[indop][1]):
-#                     myut = self._opprational[indop][1]
-#                     outcome = self._opprational[indop][2]
-#                 nextidx = max(indop-1, 0)
-#                 if(self._opprational[nextidx][0] >= opmin):
-#                     indop = nextidx
-#                 else:
-#                     break
-
-#             pre_rv = self._opprational[self.nidx][1]
-
-#             # self.opponent_ufun.reserved_value = pre_rv
-#             border = max(border,pre_rv)
-#             # if nash:
-#             #     # find my utility at the Nash Bargaining Solution.
-#             #     print(nash)
-#                 # my_nash_utility = nash[0][0][0]
-#             if(state.step <= 50):
-#                 if((self.ufun(self._best) >= self.ufun.reserved_value) and (self.ufun(self._best) >= self.nash)):
-#                     # if(self.ufun(self._best) >= self.nash):
-#                     outcome2 = self._best
-#                 else:
-#                     outcome2 = self.nasho
-#                 if(self.ufun(outcome) <=  self.ufun(outcome2)):
-#                     outcome = outcome2
-
-                    
-#             # print(self.ufun(outcome))
-#             # print(self.opponent_ufun(outcome))
-#             # outcome = self._best
-#             # print(self.predict)
-#             # if(self.ufun(self._best) > self.ufun.reserved_value):
-#             #     outcome = self._best
-#         else:
-#             outcome = self.ufun.best()
-
-            
-#         return SAOResponse(ResponseType.REJECT_OFFER, outcome)
-#         # return SAOResponse(ResponseType.REJECT_OFFER, self.ufun.best())
-
-#     def is_acceptable(self, state: SAOState) -> bool:
-#         # The acceptance strategy
-#         assert self.ufun and self.opponent_ufun
-#         # get the offer from the mechanism state
-#         offer = state.current_offer
-#         self.opponent_times.append(state.relative_time)
-#         self.opponent_utilities.append(self.opponent_ufun(offer))
-#         # If there is no offer, there is nothing to accept
-#         if offer is None:
-#             return False
-#         if((state.step)==0 or (state.step)==1):
-#             one_step = 0.0001
-#         else:
-#             # one_step = (state.relative_time) / (state.step)
-#             one_step = (self.opponent_times[-1] - self.opponent_times[1]) / (state.step - 1)
-#             # one_step3 = (self.opponent_times[-1] - self.opponent_times[0]) / (state.step)
-
-        
-#         # print("offer")
-#         # print(offer)
-#         # print(negmas.outcomes.outcome2dict(offer))
-#         # print(self.opponent_times[0])
-#         # print(self.opponent_times[1])
-        
-#         if self._best is None:
-#             if(self.ufun(offer) > self.ufun.reserved_value):
-#                 self._best = offer
-#         else:
-#             if(self.ufun(offer) > self.ufun(self._best)):
-#                 # print(self.ufun(offer))
-#                 # print(self.ufun(self._best))
-#                 self._best = offer
-#             elif(self.ufun(offer) == self.ufun(self._best)):
-#                 if(self.opponent_ufun(offer) < self.opponent_ufun(self._best)):
-#                     self._best = offer
-
-                    
-#         # Find the current aspiration level
-#         myasp = aspiration_function(
-#             state.relative_time, 1.0, self.ufun.reserved_value, self.e
-#         )
-#         opasp = aspiration_function(
-#             state.relative_time, 1.0, self.opponent_ufun.reserved_value, self.e
-#         )
-#         ans = False
-
-#         pat = self.pat * self.lasttime
-#         border = self.ufun.reserved_value
-#         if(state.relative_time >= pat):
-#             myasp = aspiration_function(pat / self.lasttime, 1.0, self.ufun.reserved_value, self.fe)
-#             ratio = (myasp - self.ufun.reserved_value) / ((self.lasttime - pat)*(self.lasttime - pat))
-#             xd = (state.relative_time / self.lasttime) - pat
-#             y = myasp - (ratio*xd*xd) 
-#             border = max(border,y)
-
-#             # asp = aspiration_function(state.relative_time, 1.0, rv, self.e)
-#             # indmy = max_rational
-#             # while(self.nidx!=0):
-#             #     nextidx = max(indmy-1 , 0)
-#             #     if(self._rational[nextidx][0] >= y):
-#             #         indmy = nextidx
-#             #     else:
-#             #         break
-#             # outcome = self._best
-#         else:
-#             # tmp = 0.0
-#             if(state.relative_time > 1.1):
-#                 popt, pcov = curve_fit(aspiration_function, self.opponent_times, self.opponent_utilities,bounds=(0, [1.0, 1.0, 1000.0]))
-#                 tmp = popt[1]
-#                 # print(state.relative_time)
-#                 # print(popt)
-#                 indop = len(self._opprational) - 1 
-#                 while(indop!=0):
-#                     nextidx = max(indop-1, 0)
-#                     if(self._opprational[nextidx][0] >= tmp):
-#                         indop = nextidx
-#                     else:
-#                         break
-
-#                 pre_rv = self._opprational[self.nidx][1]
-
-#                 # self.opponent_ufun.reserved_value = pre_rv
-#                 border = max(border,pre_rv)
-#             else:
-#                 border = self.ufun.reserved_value
-
-#             # myasp = aspiration_function(state.relative_time, 1.0, rv, self.e)
-#             # indmy = max_rational
-#             # while(self.nidx!=0):
-#             #     nextidx = max(indmy-1 , 0)
-#             #     if(self._rational[nextidx][0] >= myasp):
-#             #         indmy = nextidx
-#             #     else:
-#             #         break
-
-
-#         myasp = aspiration_function(state.relative_time, 1.0, border, self.e)
-
-
-#         # if(state.relative_time >= 0.97):
-#         #     ans = (float(self.ufun(offer)) >= myasp)
-#         # else:
-#         #     asp = max(myasp,opasp)
-#         #     ans = (float(self.ufun(offer)) >= asp)
-
-#         if(state.relative_time + 2 * one_step > 1.0):
-#             # print(self.predict)
-#             if(float(self.ufun(offer)) > self.ufun.reserved_value):
-#                 if(self.opponent_utilities[-1] <= self.opponent_utilities[-2]):
-#                     return True
-#                     # return False
-#                 # myasp = 0.0
-
-
-#         # accept if the utility of the received offer is higher than
-#         # the current aspiration
-
-#         # return ans
-#         return (float(self.ufun(offer)) >= myasp)
-
-
-
-# ?代目
-# class Shochan(SAONegotiator):
-#     """A simple negotiator that uses curve fitting to learn the reserved value.
-
-#     Args:
-#         min_unique_utilities: Number of different offers from the opponent before starting to
-#                               attempt learning their reserved value.
-#         e: The concession exponent used for the agent's offering strategy
-#         stochasticity: The level of stochasticity in the offers.
-#         enable_logging: If given, a log will be stored  for the estimates.
-
-#     Remarks:
-
-#         - Assumes that the opponent is using a time-based offering strategy that offers
-#           the outcome at utility $u(t) = (u_0 - r) - r \\exp(t^e)$ where $u_0$ is the utility of
-#           the first offer (directly read from the opponent ufun), $e$ is an exponent that controls the
-#           concession rate and $r$ is the reserved value we want to learn.
-#         - After it receives offers with enough different utilities, it starts finding the optimal values
-#           for $e$ and $r$.
-#         - When it is time to respond, RVFitter, calculates the set of rational outcomes **for both agents**
-#           based on its knowledge of the opponent ufun (given) and reserved value (learned). It then applies
-#           the same concession curve defined above to concede over an ordered list of these outcomes.
-#         - Is this better than using the same concession curve on the outcome space without even trying to learn
-#           the opponent reserved value? Maybe sometimes but empirical evaluation shows that it is not in general.
-#         - Note that the way we check for availability of enough data for training is based on the uniqueness of
-#           the utility of offers from the opponent (for the opponent). Given that these are real values, this approach
-#           is suspect because of rounding errors. If two outcomes have the same utility they may appear to have different
-#           but very close utilities because or rounding errors (or genuine very small differences). Such differences should
-#           be ignored.
-#         - Note also that we start assuming that the opponent reserved value is 0.0 which means that we are only restricted
-#           with our own reserved values when calculating the rational outcomes. This is the best case scenario for us because
-#           we have MORE negotiation power when the partner has LOWER utility.
-#     """
-#     def __init__(
-#         self,
-#         *args,
-#         min_unique_utilities: int = 10,
-#         e: float = 17.5,
-#         stochasticity: float = 0.1,
-#         enable_logging: bool = False,
-#         nash_factor=0.1,
-#         **kwargs,
-#     ):
-#         super().__init__(*args, **kwargs)
-#         self.min_unique_utilities = min_unique_utilities
-#         self.e = e
-#         self.stochasticity = stochasticity
-#         # keeps track of times at which the opponent offers
-#         self.opponent_times: list[float] = []
-#         self.my_times: list[float] = []
-#         # keeps track of opponent utilities of its offers
-#         self.opponent_utilities: list[float] = []
-#         # keeps track of the our last estimate of the opponent reserved value
-#         self._past_oppnent_rv = 0.0
-#         # keeps track of the rational outcome set given our estimate of the
-#         # opponent reserved value and our knowledge of ours
-#         self._rational: list[tuple[float, float, Outcome]] = []
-#         self._enable_logging = enable_logging
-#         self.preoffer = []
-
-#         self._outcomes: list[Outcome] = []
-#         self._min_acceptable = float("inf")
-#         self._nash_factor = nash_factor
-#         self._best: Outcome = None  # type: ignore
-#         self.nidx = 0
-#         self.opponent_ufun.reserved_value = 0.0
-#         self.lasttime = 1.0
-#         self.diffmean = 0.01
-        
-#         # self.most
-        
-
-#     def __call__(self, state: SAOState) -> SAOResponse:
-#         assert self.ufun and self.opponent_ufun
-#         # update the opponent reserved value in self.opponent_ufun
-#         # self.update_reserved_value(state)
-#         # rune the acceptance strategy and if the offer received is acceptable, accept it
-#         diff = []
-#         for i in range(len(self.opponent_times)):
-#             diff.append(self.opponent_times[i] - self.my_times[i])
-#         # diff = self.opponent_times - self.my_times
-#         if(len(diff)==0):
-#             diff_mean=0.01
-#         else:
-#             diff_mean = sum(diff) / len(diff)
-        
-#         self.diff_mean = diff_mean
-
-#         self.my_times.append(state.relative_time)
-#         if self.is_acceptable(state):
-#             # print(self.ufun(state.current_offer))
-#             # print(self.opponent_ufun(state.current_offer))
-#             # print(self.opponent_ufun.reserved_value)
-#             # print(len(self.my_times))
-#             # print(self.my_times[0])
-#             # print(self.my_times[-1])
-#             # print(len(self.opponent_times))
-#             # print(self.opponent_times[0])
-#             # print(self.opponent_times[-1])
-#             # print(state.step)
-#             # # print(state.time)
-#             # print(state.relative_time)
-#             # print(diff_mean)
-#             return SAOResponse(ResponseType.ACCEPT_OFFER, state.current_offer)
-#         else:
-#             self.preoffer.append((self.ufun(state.current_offer),self.opponent_ufun(state.current_offer)))
-#         # The offering strategy
-#         # nash
-#         ufuns = (self.ufun, self.opponent_ufun)
-#         if((state.step)==0):
-#             one_step = 0.0001
-#         else:
-#             one_step = (state.relative_time) / (state.step)
-#         lasttime = (1.0 // one_step) * one_step
-#         self.lasttime = lasttime
-
-#         # list all outcomes
-#         outcomes = list(self.ufun.outcome_space.enumerate_or_sample())
-#         # find the pareto-front and the nash point
-#         frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)
-#         frontier_outcomes = [outcomes[_] for _ in frontier_indices]
-#         my_frontier_utils = [_[0] for _ in frontier_utils]
-#         opp_frontier_utils = [_[1] for _ in frontier_utils]
-#         # print(my_frontier_utils)
-#         nash = nash_points(ufuns, frontier_utils)  # type: ignore
-#         if nash:
-#             # find my utility at the Nash Bargaining Solution.
-#             my_nash_utility = nash[0][0][0]
-#         else:
-#             my_nash_utility = 0.5 * (float(self.ufun.max()) + self.ufun.reserved_value)
-#         # Set the acceptable utility limit
-#         self._min_acceptable = my_nash_utility * self._nash_factor
-#         self._min_acceptable = self.ufun.reserved_value
-#         # self._min_acceptable = 0
-#         # Set the set of outcomes to offer from
-#         # self._outcomes = [
-#         #     w
-#         #     for u, w in zip(my_frontier_utils, frontier_outcomes)
-#         #     if u >= self._min_acceptable
-#         # ]        
-    
-#         # We only update our estimate of the rational list of outcomes if it is not set or
-#         # there is a change in estimated reserved value
-#         if (
-#             not self._rational
-#             # or abs(self.opponent_ufun.reserved_value - self._past_oppnent_rv) > 1e-3
-#         ):
-#             if(len(my_frontier_utils)!=0):
-#                 min_nash = my_frontier_utils[0]+ opp_frontier_utils[0]
-#                 for i in frontier_utils:
-#                     if(min_nash > i[0] + i[1]):
-#                         # print(min_nash)
-#                         # print(i[0] + i[1])
-#                         min_nash = i[0] + i[1]
-#                 # print(min_nash)
-            
-
-
-#             self._outcomes = [
-#                 w
-#                 for u, w in zip(my_frontier_utils, frontier_outcomes)
-#                 if u >= self.ufun.reserved_value
-#             ]     
-
-#             if(len(my_frontier_utils)!=0):
-#                 for _ in outcomes:
-#                     if (float(self.ufun(_)) + float(self.opponent_ufun(_)) >= min_nash):
-#                         if( _ not in self._outcomes):
-#                             self._outcomes.append(_)
-
-
-#             # self._rational = sorted(
-#             #     [
-#             #         (my_util, opp_util, _)
-#             #         for _ in self._outcomes
-#             #         if (my_util := float(self.ufun(_))) > 0
-#             #         and (opp_util := float(self.opponent_ufun(_)))
-#             #         > 0
-#             #     ],
-#             # )
-#             self._rational = sorted(
-#                 [
-#                     (my_util, opp_util, _)
-#                     for _ in self._outcomes
-#                     if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#                     and (opp_util := float(self.opponent_ufun(_)))
-#                     > 0
-#                 ],
-#             )
-#             self.nidx = len(self._rational)-1
-
-#             self._opprational = sorted(
-#                 [
-#                     (opp_util, my_util, _)
-#                     for _ in self._outcomes
-#                     if (my_util := float(self.ufun(_))) > 0
-#                     # if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#                     and (opp_util := float(self.opponent_ufun(_)))
-#                     > 0
-#                 ],
-#             )
-#             # print(self.nidx)
-#         # If there are no rational outcomes (i.e. our estimate of the opponent rv is very wrogn),
-#         # then just revert to offering our top offer
-#         max_rational = len(self._rational) - 1
-#         if not self._rational:
-#             return SAOResponse(ResponseType.REJECT_OFFER, self.ufun.best())
-        
-
-#         # find our aspiration level (value between 0 and 1) the higher the higher utility we require
-#         asp = aspiration_function(state.relative_time, 1.0, 0.0, self.e)
-#         # find the index of the rational outcome at the aspiration level (in the rational set of outcomes)
-#         n_rational = len(self._rational)
-#         max_rational = n_rational - 1
-#         pat = 0.95 * self.lasttime
-#         border = self.ufun.reserved_value
-#         if(state.relative_time >= pat):
-#             myasp = aspiration_function(pat / self.lasttime, 1.0, self.ufun.reserved_value, self.e)
-#             ratio = (myasp - self.ufun.reserved_value) / ((lasttime - pat)*(lasttime - pat))
-#             xd = (state.relative_time / self.lasttime) - pat
-#             y = myasp - (ratio*xd*xd) 
-#             border = max(border,y)
-
-#             # asp = aspiration_function(state.relative_time, 1.0, rv, self.e)
-#             # indmy = max_rational
-#             # while(self.nidx!=0):
-#             #     nextidx = max(indmy-1 , 0)
-#             #     if(self._rational[nextidx][0] >= y):
-#             #         indmy = nextidx
-#             #     else:
-#             #         break
-#             # outcome = self._best
-#         else:
-#             # tmp = 0.0
-#             if(state.relative_time > 1.1):
-#                 popt, pcov = curve_fit(aspiration_function, self.opponent_times, self.opponent_utilities,bounds=(0, [1.0, 1.0, 1000.0]))
-#                 tmp = popt[1]
-#                 # print(state.relative_time)
-#                 # print(popt)
-#                 indop = len(self._opprational) - 1 
-#                 while(indop!=0):
-#                     nextidx = max(indop, 0)
-#                     if(self._opprational[nextidx][0] >= tmp):
-#                         indop = nextidx
-#                     else:
-#                         break
-
-#                 pre_rv = self._opprational[self.nidx][1]
-
-#                 # self.opponent_ufun.reserved_value = pre_rv
-#                 border = max(border,pre_rv)
-#             else:
-#                 border = self.ufun.reserved_value
-
-#             # myasp = aspiration_function(state.relative_time, 1.0, rv, self.e)
-#             # indmy = max_rational
-#             # while(self.nidx!=0):
-#             #     nextidx = max(indmy-1 , 0)
-#             #     if(self._rational[nextidx][0] >= myasp):
-#             #         indmy = nextidx
-#             #     else:
-#             #         break
-
-
-#         myasp = aspiration_function(state.relative_time / self.lasttime, 1.0, border, self.e)
-#         indmy = max_rational
-#         while(indmy!=0):
-#             nextidx = max(indmy-1 , 0)
-#             if(self._rational[nextidx][0] >= myasp):
-#                 indmy = nextidx
-#             else:
-#                 break
-        
-#         indx = indmy
-#         outcome = self._rational[indx][-1]
-
-#         if(state.relative_time + one_step > 1.0):
-#             if(self.ufun(self._best) > self.ufun.reserved_value):
-#                 outcome = self._best
-#         # print(state.step)
-
-#         return SAOResponse(ResponseType.REJECT_OFFER, outcome)
-#         # return SAOResponse(ResponseType.REJECT_OFFER, self.ufun.best())
-
-#     def is_acceptable(self, state: SAOState) -> bool:
-#         # The acceptance strategy
-#         assert self.ufun and self.opponent_ufun
-#         # get the offer from the mechanism state
-#         offer = state.current_offer
-#         # If there is no offer, there is nothing to accept
-#         if offer is None:
-#             return False
-        
-#         # print("offer")
-#         # print(offer)
-        
-#         if self._best is None:
-#             self._best = offer
-#         else:
-#             if(self.ufun(offer) > self.ufun(self._best)):
-#                 # print(self.ufun(offer))
-#                 # print(self.ufun(self._best))
-#                 self._best = offer
-#             elif(self.ufun(offer) == self.ufun(self._best)):
-#                 if(self.opponent_ufun(offer) < self.opponent_ufun(self._best)):
-#                     self._best = offer
-
-#         self.opponent_times.append(state.relative_time)
-#         self.opponent_utilities.append(self.opponent_ufun(offer))
-                    
-#         # Find the current aspiration level
-#         myasp = aspiration_function(
-#             state.relative_time / self.lasttime, 1.0, self.ufun.reserved_value, self.e
-#         )
-#         opasp = aspiration_function(
-#             state.relative_time / self.lasttime, 1.0, self.opponent_ufun.reserved_value, self.e
-#         )
-#         ans = False
-
-#         pat = 0.95 * self.lasttime
-#         border = self.ufun.reserved_value
-#         if(state.relative_time >= pat):
-#             myasp = aspiration_function(pat / self.lasttime, 1.0, self.ufun.reserved_value, self.e)
-#             ratio = (myasp - self.ufun.reserved_value) / ((self.lasttime - pat)*(self.lasttime - pat))
-#             xd = (state.relative_time / self.lasttime) - pat
-#             y = myasp - (ratio*xd*xd) 
-#             border = max(border,y)
-
-#             # asp = aspiration_function(state.relative_time, 1.0, rv, self.e)
-#             # indmy = max_rational
-#             # while(self.nidx!=0):
-#             #     nextidx = max(indmy-1 , 0)
-#             #     if(self._rational[nextidx][0] >= y):
-#             #         indmy = nextidx
-#             #     else:
-#             #         break
-#             # outcome = self._best
-#         else:
-#             # tmp = 0.0
-#             if(state.relative_time > 1.1):
-#                 popt, pcov = curve_fit(aspiration_function, self.opponent_times, self.opponent_utilities,bounds=(0, [1.0, 1.0, 1000.0]))
-#                 tmp = popt[1]
-#                 # print(state.relative_time)
-#                 # print(popt)
-#                 indop = len(self._opprational) - 1 
-#                 while(indop!=0):
-#                     nextidx = max(indop, 0)
-#                     if(self._opprational[nextidx][0] >= tmp):
-#                         indop = nextidx
-#                     else:
-#                         break
-
-#                 pre_rv = self._opprational[self.nidx][1]
-
-#                 # self.opponent_ufun.reserved_value = pre_rv
-#                 border = max(border,pre_rv)
-#             else:
-#                 border = self.ufun.reserved_value
-
-#             # myasp = aspiration_function(state.relative_time, 1.0, rv, self.e)
-#             # indmy = max_rational
-#             # while(self.nidx!=0):
-#             #     nextidx = max(indmy-1 , 0)
-#             #     if(self._rational[nextidx][0] >= myasp):
-#             #         indmy = nextidx
-#             #     else:
-#             #         break
-
-
-#         myasp = aspiration_function(state.relative_time / self.lasttime, 1.0, border, self.e)
-
-
-#         # if(state.relative_time >= 0.97):
-#         #     ans = (float(self.ufun(offer)) >= myasp)
-#         # else:
-#         #     asp = max(myasp,opasp)
-#         #     ans = (float(self.ufun(offer)) >= asp)
-
-
-#         # accept if the utility of the received offer is higher than
-#         # the current aspiration
-#         if(self.opponent_times[-1] + self.diff_mean > 1.0):
-#             if(self.ufun(offer) > self.ufun.reserved_value):
-#                 return True
-
-#         # return ans
-#         return (float(self.ufun(offer)) >= myasp)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    # def update_reserved_value(self, state: SAOState):
-    #     # Learns the reserved value of the partner
-    #     assert self.opponent_ufun is not None
-    #     # extract the current offer from the state
-    #     offer = state.current_offer
-    #     if offer is None:
-    #         return
-    #     # save to the list of utilities received from the opponent and their times
-    #     self.opponent_utilities.append(float(self.opponent_ufun(offer)))
-    #     self.opponent_times.append(state.relative_time)
-
-    #     # If we do not have enough data, just assume that the opponent
-    #     # reserved value is zero
-    #     n_unique = len(set(self.opponent_utilities))
-    #     if n_unique < self.min_unique_utilities:
-    #         self._past_oppnent_rv = 0.0
-    #         self.opponent_ufun.reserved_value = 0.0
-    #         return
-    #     # Use curve fitting to estimate the opponent reserved value
-    #     # We assume the following:
-    #     # - The opponent is using a concession strategy with an exponent between 0.2, 5.0
-    #     # - The opponent never offers outcomes lower than their reserved value which means
-    #     #   that their rv must be no higher than the worst outcome they offered for themselves.
-    #     bounds = ((0.2, 0.0), (5.0, min(self.opponent_utilities)))
-    #     err = ""
-    #     try:
-    #         optimal_vals, _ = curve_fit(
-    #             lambda x, e, rv: aspiration_function(
-    #                 x, self.opponent_utilities[0], rv, e
-    #             ),
-    #             self.opponent_times,
-    #             self.opponent_utilities,
-    #             bounds=bounds,
-    #         )
-    #         self._past_oppnent_rv = self.opponent_ufun.reserved_value
-    #         self.opponent_ufun.reserved_value = optimal_vals[1]
-    #     except Exception as e:
-    #         err, optimal_vals = f"{str(e)}", [None, None]
-
-    #     # log my estimate
-    #     if self._enable_logging:
-    #         self.nmi.log_info(
-    #             self.id,
-    #             dict(
-    #                 estimated_rv=self.opponent_ufun.reserved_value,
-    #                 n_unique=n_unique,
-    #                 opponent_utility=self.opponent_utilities[-1],
-    #                 estimated_exponent=optimal_vals[0],
-    #                 estimated_max=self.opponent_utilities[0],
-    #                 error=err,
-    #             ),
-    #         )
-
-# 2代目
-# class Shochan(SAONegotiator):
-#     """A simple negotiator that uses curve fitting to learn the reserved value.
-
-#     Args:
-#         min_unique_utilities: Number of different offers from the opponent before starting to
-#                               attempt learning their reserved value.
-#         e: The concession exponent used for the agent's offering strategy
-#         stochasticity: The level of stochasticity in the offers.
-#         enable_logging: If given, a log will be stored  for the estimates.
-
-#     Remarks:
-
-#         - Assumes that the opponent is using a time-based offering strategy that offers
-#           the outcome at utility $u(t) = (u_0 - r) - r \\exp(t^e)$ where $u_0$ is the utility of
-#           the first offer (directly read from the opponent ufun), $e$ is an exponent that controls the
-#           concession rate and $r$ is the reserved value we want to learn.
-#         - After it receives offers with enough different utilities, it starts finding the optimal values
-#           for $e$ and $r$.
-#         - When it is time to respond, RVFitter, calculates the set of rational outcomes **for both agents**
-#           based on its knowledge of the opponent ufun (given) and reserved value (learned). It then applies
-#           the same concession curve defined above to concede over an ordered list of these outcomes.
-#         - Is this better than using the same concession curve on the outcome space without even trying to learn
-#           the opponent reserved value? Maybe sometimes but empirical evaluation shows that it is not in general.
-#         - Note that the way we check for availability of enough data for training is based on the uniqueness of
-#           the utility of offers from the opponent (for the opponent). Given that these are real values, this approach
-#           is suspect because of rounding errors. If two outcomes have the same utility they may appear to have different
-#           but very close utilities because or rounding errors (or genuine very small differences). Such differences should
-#           be ignored.
-#         - Note also that we start assuming that the opponent reserved value is 0.0 which means that we are only restricted
-#           with our own reserved values when calculating the rational outcomes. This is the best case scenario for us because
-#           we have MORE negotiation power when the partner has LOWER utility.
-#     """
-
-#     def __init__(
-#         self,
-#         *args,
-#         min_unique_utilities: int = 10,
-#         e: float = 17.5,
-#         stochasticity: float = 0.1,
-#         enable_logging: bool = False,
-#         nash_factor=0.1,
-#         **kwargs,
-#     ):
-#         super().__init__(*args, **kwargs)
-#         self.min_unique_utilities = min_unique_utilities
-#         self.e = e
-#         self.stochasticity = stochasticity
-#         # keeps track of times at which the opponent offers
-#         self.opponent_times: list[float] = []
-#         # keeps track of opponent utilities of its offers
-#         self.opponent_utilities: list[float] = []
-#         # keeps track of the our last estimate of the opponent reserved value
-#         self._past_oppnent_rv = 0.0
-#         # keeps track of the rational outcome set given our estimate of the
-#         # opponent reserved value and our knowledge of ours
-#         self._rational: list[tuple[float, float, Outcome]] = []
-#         self._enable_logging = enable_logging
-#         self.preoffer = []
-
-#         self._outcomes: list[Outcome] = []
-#         self._min_acceptable = float("inf")
-#         self._nash_factor = nash_factor
-#         self._best: Outcome = None  # type: ignore
-#         self.nidx = 0
-#         self.opponent_ufun.reserved_value = 0.0
-#         # self.most
-        
-
-#     def __call__(self, state: SAOState) -> SAOResponse:
-#         assert self.ufun and self.opponent_ufun
-#         # update the opponent reserved value in self.opponent_ufun
-#         # self.update_reserved_value(state)
-#         # rune the acceptance strategy and if the offer received is acceptable, accept it
-#         if self.is_acceptable(state):
-#             # print(self.ufun(state.current_offer))
-#             # print(self.opponent_ufun(state.current_offer))
-#             # print(self.opponent_ufun.reserved_value)
-#             return SAOResponse(ResponseType.ACCEPT_OFFER, state.current_offer)
-#         else:
-#             self.preoffer.append((self.ufun(state.current_offer),self.opponent_ufun(state.current_offer)))
-#         # The offering strategy
-            
-#         # nash
-#         ufuns = (self.ufun, self.opponent_ufun)
-#         # list all outcomes
-#         outcomes = list(self.ufun.outcome_space.enumerate_or_sample())
-#         # find the pareto-front and the nash point
-#         frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)
-#         frontier_outcomes = [outcomes[_] for _ in frontier_indices]
-#         my_frontier_utils = [_[0] for _ in frontier_utils]
-#         opp_frontier_utils = [_[1] for _ in frontier_utils]
-#         # print(my_frontier_utils)
-#         nash = nash_points(ufuns, frontier_utils)  # type: ignore
-#         if nash:
-#             # find my utility at the Nash Bargaining Solution.
-#             my_nash_utility = nash[0][0][0]
-#         else:
-#             my_nash_utility = 0.5 * (float(self.ufun.max()) + self.ufun.reserved_value)
-#         # Set the acceptable utility limit
-#         self._min_acceptable = my_nash_utility * self._nash_factor
-#         self._min_acceptable = self.ufun.reserved_value
-#         # self._min_acceptable = 0
-#         # Set the set of outcomes to offer from
-
-      
-#         # self._outcomes = [
-#         #     w
-#         #     for u, w in zip(my_frontier_utils, frontier_outcomes)
-#         #     if u >= self._min_acceptable
-#         # ]        
-    
-#         # We only update our estimate of the rational list of outcomes if it is not set or
-#         # there is a change in estimated reserved value
-#         if (
-#             not self._rational
-#             # or abs(self.opponent_ufun.reserved_value - self._past_oppnent_rv) > 1e-3
-#         ):
-#             # The rational set of outcomes sorted dependingly according to our utility function
-#             # and the opponent utility function (in that order).
-#             # self._rational = sorted(
-#             #     [
-#             #         (my_util, opp_util, _)
-#             #         for _ in self.nmi.outcome_space.enumerate_or_sample(
-#             #             levels=10, max_cardinality=100_000
-#             #         )
-#             #         if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#             #         and (opp_util := float(self.opponent_ufun(_)))
-#             #         > self.opponent_ufun.reserved_value
-#             #     ],
-#             # )
-
-#             # a = set([])
-#             # b = set([])
-#             # ori_outcomes = []
-#             # tmp = sorted(
-#             #     [
-#             #         (float(self.ufun(_)), float(self.opponent_ufun(_)), _)
-#             #         for _ in outcomes
-#             #     ],reverse=True
-#             # )
-
-#             # ori_outcomes2 = []
-#             # tmp2 = sorted(
-#             #     [
-#             #         (float(self.opponent_ufun(_)), float(self.ufun(_)), _)
-#             #         for _ in outcomes
-#             #     ],reverse=True
-#             # )
-#             # # print(tmp[20])
-#             # # i = 0
-#             # # print("---------------------------------------------------")
-#             # for i in range(len(tmp)):
-#             #     # print(i)
-#             #     # print(tmp[i])
-#             #     if(tmp[i][0] not in a):
-#             #         a.add(tmp[i][0])
-#             #         if(tmp[i][0] >= self.ufun.reserved_value):
-#             #             ori_outcomes.append(tmp[i][-1]) 
-
-#             # for i in range(len(tmp2)):
-#             #     # print(i)
-#             #     # print(tmp[i])
-#             #     if(tmp2[i][0] not in b):
-#             #         b.add(tmp2[i][0])
-#             #         if(tmp2[i][0] >= self.ufun.reserved_value):
-#             #             ori_outcomes2.append(tmp2[i][-1]) 
-#             #             # print([tmp[i][0],tmp[i][1]])    
-#             #             # print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-#             # c = set(ori_outcomes)
-#             # for i in ori_outcomes2:
-#             #     c.add(i)
-#             # all_outcomes = list(c)
-#             # self._outcomes = all_outcomes
-#             # print(my_frontier_utils)
-#             if(len(my_frontier_utils)!=0):
-#                 min_nash = my_frontier_utils[0]+ opp_frontier_utils[0]
-#                 for i in frontier_utils:
-#                     if(min_nash > i[0] + i[1]):
-#                         # print(min_nash)
-#                         # print(i[0] + i[1])
-#                         min_nash = i[0] + i[1]
-#                 # print(min_nash)
-            
-
-
-#             self._outcomes = [
-#                 w
-#                 for u, w in zip(my_frontier_utils, frontier_outcomes)
-#                 if u >= self.ufun.reserved_value
-#             ]     
-
-#             if(len(my_frontier_utils)!=0):
-#                 for _ in outcomes:
-#                     if (float(self.ufun(_)) + float(self.opponent_ufun(_)) >= min_nash):
-#                         if( _ not in self._outcomes):
-#                             self._outcomes.append(_)
-
-
-#             # self._rational = sorted(
-#             #     [
-#             #         (my_util, opp_util, _)
-#             #         for _ in self._outcomes
-#             #         if (my_util := float(self.ufun(_))) > 0
-#             #         and (opp_util := float(self.opponent_ufun(_)))
-#             #         > 0
-#             #     ],
-#             # )
-#             self._rational = sorted(
-#                 [
-#                     (my_util, opp_util, _)
-#                     for _ in self._outcomes
-#                     if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#                     and (opp_util := float(self.opponent_ufun(_)))
-#                     > 0
-#                 ],
-#             )
-#             self.nidx = len(self._rational)-1
-
-#             self._opprational = sorted(
-#                 [
-#                     (opp_util, my_util, _)
-#                     for _ in self._outcomes
-#                     if (my_util := float(self.ufun(_))) > 0
-#                     # if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#                     and (opp_util := float(self.opponent_ufun(_)))
-#                     > 0
-#                 ],
-#             )
-#             # print(self.nidx)
-#         # If there are no rational outcomes (i.e. our estimate of the opponent rv is very wrogn),
-#         # then just revert to offering our top offer
-#         max_rational = len(self._rational) - 1
-#         if not self._rational:
-#             return SAOResponse(ResponseType.REJECT_OFFER, self.ufun.best())
-#         # find our aspiration level (value between 0 and 1) the higher the higher utility we require
-#         # asp = aspiration_function(state.relative_time, 1.0, 0.0, self.e)
-#         # find the index of the rational outcome at the aspiration level (in the rational set of outcomes)
-#         # n_rational = len(self._rational)
-#         # min_indx = max(0, min(max_rational, int(asp * max_rational)))
-
-#         min_indx = self.nidx
-        
-#         # find current stochasticity which goes down from the set level to zero linearly
-#         # s = aspiration_function(state.relative_time, self.stochasticity, 0.0, 1.0)
-#         # find the index of the maximum utility we require based on stochasticity (going down over time)
-#         # max_indx = max(0, min(int(min_indx + s * n_rational), max_rational))
-#         # max_indx = max(0, min(int(min_indx + s * n_rational), max_rational))
-#         # offer an outcome in the selected range
-#         # indx = random.randint(min_indx, max_indx) if min_indx != max_indx else min_indx
-
-#         # print("outcome")
-#         # print(outcome)
-#         # if(self.ufun(self._best) > self.ufun(outcome) and self.ufun(self._best) > self.ufun.reserved_value):
-#         #     outcome = self._best
-#         # if(state.relative_time > 0.95 and self.ufun(self._best) > self.ufun.reserved_value)
-#         pat = 0.95
-#         border = self.ufun.reserved_value
-#         if(state.relative_time >= pat):
-#             myasp = aspiration_function(pat, 1.0, self.ufun.reserved_value, self.e)
-#             ratio = (myasp - self.ufun.reserved_value) / ((1.0 - pat)*(1.0 - pat))
-#             xd = state.relative_time - pat
-#             y = myasp - (ratio*xd*xd) 
-#             border = max(border,y)
-
-#             # asp = aspiration_function(state.relative_time, 1.0, rv, self.e)
-#             # indmy = max_rational
-#             # while(self.nidx!=0):
-#             #     nextidx = max(indmy-1 , 0)
-#             #     if(self._rational[nextidx][0] >= y):
-#             #         indmy = nextidx
-#             #     else:
-#             #         break
-#             # outcome = self._best
-#         else:
-#             # tmp = 0.0
-#             if(state.relative_time > 1.1):
-#                 popt, pcov = curve_fit(aspiration_function, self.opponent_times, self.opponent_utilities,bounds=(0, [1.0, 1.0, 1000.0]))
-#                 tmp = popt[1]
-#                 # print(state.relative_time)
-#                 # print(popt)
-#                 indop = len(self._opprational) - 1 
-#                 while(self.nidx!=0):
-#                     nextidx = max(indop, 0)
-#                     if(self._opprational[nextidx][0] >= tmp):
-#                         indop = nextidx
-#                     else:
-#                         break
-
-#                 pre_rv = self._opprational[self.nidx][1]
-
-#                 # self.opponent_ufun.reserved_value = pre_rv
-#                 border = max(border,pre_rv)
-#             else:
-#                 border = self.ufun.reserved_value
-
-#             # myasp = aspiration_function(state.relative_time, 1.0, rv, self.e)
-#             # indmy = max_rational
-#             # while(self.nidx!=0):
-#             #     nextidx = max(indmy-1 , 0)
-#             #     if(self._rational[nextidx][0] >= myasp):
-#             #         indmy = nextidx
-#             #     else:
-#             #         break
-
-
-#         myasp = aspiration_function(state.relative_time, 1.0, border, self.e)
-#         indmy = max_rational
-#         while(self.nidx!=0):
-#             nextidx = max(indmy-1 , 0)
-#             if(self._rational[nextidx][0] >= myasp):
-#                 indmy = nextidx
-#             else:
-#                 break
-        
-#         indx = indmy
-#         outcome = self._rational[indx][-1]
-
-#         # return SAOResponse(ResponseType.REJECT_OFFER, outcome)
-#         return SAOResponse(ResponseType.REJECT_OFFER, self.ufun.best())
-
-#     def is_acceptable(self, state: SAOState) -> bool:
-#         # The acceptance strategy
-#         assert self.ufun and self.opponent_ufun
-#         # get the offer from the mechanism state
-#         offer = state.current_offer
-#         # If there is no offer, there is nothing to accept
-#         if offer is None:
-#             return False
-        
-#         # print("offer")
-#         # print(offer)
-        
-#         if self._best is None:
-#             self._best = offer
-#         else:
-#             if(self.ufun(offer) > self.ufun(self._best)):
-#                 # print(self.ufun(offer))
-#                 # print(self.ufun(self._best))
-#                 self._best = offer
-#             elif(self.ufun(offer) == self.ufun(self._best)):
-#                 if(self.opponent_ufun(offer) < self.opponent_ufun(self._best)):
-#                     self._best = offer
-
-#         self.opponent_times.append(state.relative_time)
-#         self.opponent_utilities.append(self.opponent_ufun(offer))
-                    
-#         # Find the current aspiration level
-#         myasp = aspiration_function(
-#             state.relative_time, 1.0, self.ufun.reserved_value, self.e
-#         )
-#         opasp = aspiration_function(
-#             state.relative_time, 1.0, self.opponent_ufun.reserved_value, self.e
-#         )
-#         ans = False
-
-
-#         # if(state.relative_time >= 0.97):
-#         #     ans = (float(self.ufun(offer)) >= myasp)
-#         # else:
-#         #     asp = max(myasp,opasp)
-#         #     ans = (float(self.ufun(offer)) >= asp)
-
-
-#         # accept if the utility of the received offer is higher than
-#         # the current aspiration
-
-#         # return ans
-#         return (float(self.ufun(offer)) >= myasp)
-
-#     # def update_reserved_value(self, state: SAOState):
-#     #     # Learns the reserved value of the partner
-#     #     assert self.opponent_ufun is not None
-#     #     # extract the current offer from the state
-#     #     offer = state.current_offer
-#     #     if offer is None:
-#     #         return
-#     #     # save to the list of utilities received from the opponent and their times
-#     #     self.opponent_utilities.append(float(self.opponent_ufun(offer)))
-#     #     self.opponent_times.append(state.relative_time)
-
-#     #     # If we do not have enough data, just assume that the opponent
-#     #     # reserved value is zero
-#     #     n_unique = len(set(self.opponent_utilities))
-#     #     if n_unique < self.min_unique_utilities:
-#     #         self._past_oppnent_rv = 0.0
-#     #         self.opponent_ufun.reserved_value = 0.0
-#     #         return
-#     #     # Use curve fitting to estimate the opponent reserved value
-#     #     # We assume the following:
-#     #     # - The opponent is using a concession strategy with an exponent between 0.2, 5.0
-#     #     # - The opponent never offers outcomes lower than their reserved value which means
-#     #     #   that their rv must be no higher than the worst outcome they offered for themselves.
-#     #     bounds = ((0.2, 0.0), (5.0, min(self.opponent_utilities)))
-#     #     err = ""
-#     #     try:
-#     #         optimal_vals, _ = curve_fit(
-#     #             lambda x, e, rv: aspiration_function(
-#     #                 x, self.opponent_utilities[0], rv, e
-#     #             ),
-#     #             self.opponent_times,
-#     #             self.opponent_utilities,
-#     #             bounds=bounds,
-#     #         )
-#     #         self._past_oppnent_rv = self.opponent_ufun.reserved_value
-#     #         self.opponent_ufun.reserved_value = optimal_vals[1]
-#     #     except Exception as e:
-#     #         err, optimal_vals = f"{str(e)}", [None, None]
-
-#     #     # log my estimate
-#     #     if self._enable_logging:
-#     #         self.nmi.log_info(
-#     #             self.id,
-#     #             dict(
-#     #                 estimated_rv=self.opponent_ufun.reserved_value,
-#     #                 n_unique=n_unique,
-#     #                 opponent_utility=self.opponent_utilities[-1],
-#     #                 estimated_exponent=optimal_vals[0],
-#     #                 estimated_max=self.opponent_utilities[0],
-#     #                 error=err,
-#     #             ),
-#     #         )
-
-# class Shochan(SAONegotiator):
-#     """A simple negotiator that uses curve fitting to learn the reserved value.
-
-#     Args:
-#         min_unique_utilities: Number of different offers from the opponent before starting to
-#                               attempt learning their reserved value.
-#         e: The concession exponent used for the agent's offering strategy
-#         stochasticity: The level of stochasticity in the offers.
-#         enable_logging: If given, a log will be stored  for the estimates.
-
-#     Remarks:
-
-#         - Assumes that the opponent is using a time-based offering strategy that offers
-#           the outcome at utility $u(t) = (u_0 - r) - r \\exp(t^e)$ where $u_0$ is the utility of
-#           the first offer (directly read from the opponent ufun), $e$ is an exponent that controls the
-#           concession rate and $r$ is the reserved value we want to learn.
-#         - After it receives offers with enough different utilities, it starts finding the optimal values
-#           for $e$ and $r$.
-#         - When it is time to respond, RVFitter, calculates the set of rational outcomes **for both agents**
-#           based on its knowledge of the opponent ufun (given) and reserved value (learned). It then applies
-#           the same concession curve defined above to concede over an ordered list of these outcomes.
-#         - Is this better than using the same concession curve on the outcome space without even trying to learn
-#           the opponent reserved value? Maybe sometimes but empirical evaluation shows that it is not in general.
-#         - Note that the way we check for availability of enough data for training is based on the uniqueness of
-#           the utility of offers from the opponent (for the opponent). Given that these are real values, this approach
-#           is suspect because of rounding errors. If two outcomes have the same utility they may appear to have different
-#           but very close utilities because or rounding errors (or genuine very small differences). Such differences should
-#           be ignored.
-#         - Note also that we start assuming that the opponent reserved value is 0.0 which means that we are only restricted
-#           with our own reserved values when calculating the rational outcomes. This is the best case scenario for us because
-#           we have MORE negotiation power when the partner has LOWER utility.
-#     """
-
-#     def __init__(
-#         self,
-#         *args,
-#         min_unique_utilities: int = 10,
-#         e: float = 15.0,
-#         stochasticity: float = 0.1,
-#         enable_logging: bool = False,
-#         nash_factor=0.1,
-#         **kwargs,
-#     ):
-#         super().__init__(*args, **kwargs)
-#         self.min_unique_utilities = min_unique_utilities
-#         self.e = e
-#         self.stochasticity = stochasticity
-#         # keeps track of times at which the opponent offers
-#         self.opponent_times: list[float] = []
-#         # keeps track of opponent utilities of its offers
-#         self.opponent_utilities: list[float] = []
-#         # keeps track of the our last estimate of the opponent reserved value
-#         self._past_oppnent_rv = 0.0
-#         # keeps track of the rational outcome set given our estimate of the
-#         # opponent reserved value and our knowledge of ours
-#         self._rational: list[tuple[float, float, Outcome]] = []
-#         self._enable_logging = enable_logging
-#         self.preoffer = []
-
-#         self._outcomes: list[Outcome] = []
-#         self._min_acceptable = float("inf")
-#         self._nash_factor = nash_factor
-#         self._best: Outcome = None  # type: ignore
-#         self.nidx = 0
-#         self.opponent_ufun.reserved_value = 25.0
-#         # self.most
-        
-
-#     def __call__(self, state: SAOState) -> SAOResponse:
-#         assert self.ufun and self.opponent_ufun
-#         # update the opponent reserved value in self.opponent_ufun
-#         # self.update_reserved_value(state)
-#         # rune the acceptance strategy and if the offer received is acceptable, accept it
-#         if self.is_acceptable(state):
-#             # print(self.opponent_times)
-#             # print(self.opponent_utilities)
-#             # print(self.opponent_ufun(state.current_offer))
-#             # print(self.opponent_ufun.reserved_value)
-#             # xdata = 
-#             # print(self.opponent_)
-#             popt, pcov = curve_fit(aspiration_function, self.opponent_times, self.opponent_utilities,bounds=(0, [1.0, 1.0, 100.0]))
-#             # print(state.current_proposer_agent)
-#             # print(state.new_offerer_agents)
-#             # print(self.annotation)
-#             # print(self.capabilities)
-#             # print(self.crisp_ufun)
-#             # print(self.id)
-#             # print(self.name)
-#             # print(self.owner)
-#             # print(self.parent)
-#             # print(self.preferences)
-#             # print(self.private_info)
-#             # print(self.prob_ufun)
-#             # print(self.reserved_outcome)
-#             # print(self.short_type_name)
-#             # print(self.type_name)
-#             # print(self.ufun)
-#             # print(self.uuid)
-#             print(state.relative_time)
-#             print(popt)
-#             # plt.plot(self.opponent_times, aspiration_function(self.opponent_times, *popt), 'r-',label='fit: a=%5.3f, b=%5.3f, c=%5.3f' % tuple(popt))
-#             # plt.xlabel('x')
-#             # plt.ylabel('y')
-#             # plt.legend()
-#             # plt.savefig("/root/negmas/")  
-#             # plt.show()
-#             return SAOResponse(ResponseType.ACCEPT_OFFER, state.current_offer)
-#         else:
-#             self.preoffer.append((self.ufun(state.current_offer),self.opponent_ufun(state.current_offer)))
-#         # The offering strategy
-            
-#         # nash
-#         ufuns = (self.ufun, self.opponent_ufun)
-#         # list all outcomes
-#         outcomes = list(self.ufun.outcome_space.enumerate_or_sample())
-#         # print(outcomes)
-#         # find the pareto-front and the nash point
-#         frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)
-#         frontier_outcomes = [outcomes[_] for _ in frontier_indices]
-#         # print(frontier_outcomes)
-#         # print(frontier_utils)
-#         my_frontier_utils = [_[0] for _ in frontier_utils]
-#         opp_frontier_utils = [_[1] for _ in frontier_utils]
-#         # print(my_frontier_utils)
-#         # print(opp_frontier_utils)
-#         nash = nash_points(ufuns, frontier_utils)  # type: ignore
-#         if nash:
-#             # find my utility at the Nash Bargaining Solution.
-#             my_nash_utility = nash[0][0][0]
-#         else:
-#             my_nash_utility = 0.5 * (float(self.ufun.max()) + self.ufun.reserved_value)
-#         # Set the acceptable utility limit
-#         self._min_acceptable = my_nash_utility * self._nash_factor
-#         self._min_acceptable = self.ufun.reserved_value
-#         # self._min_acceptable = 0
-#         # Set the set of outcomes to offer from
-
-      
-#         # self._outcomes = [
-#         #     w
-#         #     for u, w in zip(my_frontier_utils, frontier_outcomes)
-#         #     if u >= self._min_acceptable
-#         # ]        
-    
-#         # We only update our estimate of the rational list of outcomes if it is not set or
-#         # there is a change in estimated reserved value
-#         if (
-#             not self._rational
-#             or abs(self.opponent_ufun.reserved_value - self._past_oppnent_rv) > 1e-3
-#         ):
-#             # The rational set of outcomes sorted dependingly according to our utility function
-#             # and the opponent utility function (in that order).
-#             # self._rational = sorted(
-#             #     [
-#             #         (my_util, opp_util, _)
-#             #         for _ in self.nmi.outcome_space.enumerate_or_sample(
-#             #             levels=10, max_cardinality=100_000
-#             #         )
-#             #         if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#             #         and (opp_util := float(self.opponent_ufun(_)))
-#             #         > self.opponent_ufun.reserved_value
-#             #     ],
-#             # )
-#             a = set([])
-#             b = set([])
-#             ori_outcomes = []
-#             tmp = sorted(
-#                 [
-#                     (float(self.ufun(_)), float(self.opponent_ufun(_)), _)
-#                     for _ in outcomes
-#                 ],reverse=True
-#             )
-
-#             ori_outcomes2 = []
-#             tmp2 = sorted(
-#                 [
-#                     (float(self.opponent_ufun(_)), float(self.ufun(_)), _)
-#                     for _ in outcomes
-#                 ],reverse=True
-#             )
-#             # print(tmp[20])
-#             # i = 0
-#             # print("---------------------------------------------------")
-#             for i in range(len(tmp)):
-#                 # print(i)
-#                 # print(tmp[i])
-#                 if(tmp[i][0] not in a):
-#                     a.add(tmp[i][0])
-#                     if(tmp[i][0] >= self.ufun.reserved_value):
-#                         ori_outcomes.append(tmp[i][-1]) 
-
-#             for i in range(len(tmp2)):
-#                 # print(i)
-#                 # print(tmp[i])
-#                 if(tmp2[i][0] not in b):
-#                     b.add(tmp2[i][0])
-#                     if(tmp2[i][0] >= self.ufun.reserved_value):
-#                         ori_outcomes2.append(tmp2[i][-1]) 
-#                         # print([tmp[i][0],tmp[i][1]])    
-#                         # print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-#             c = set(ori_outcomes)
-#             for i in ori_outcomes2:
-#                 c.add(i)
-#             all_outcomes = list(c)
-#             self._outcomes = all_outcomes
-#             # print()
-
-#             # min_nash = my_frontier_utils[0]+opp_frontier_utils[0]
-#             # for i in frontier_utils:
-#             #     if(min_nash > i[0] + i[1]):
-#             #         print(min_nash[0]+min_nash[1])
-#             #         print(i[0] + i[1])
-#             #         min_nash = i
-#                 # print(min_nash)
-            
-
-#             self._outcomes = [
-#                 w
-#                 for u, w in zip(my_frontier_utils, frontier_outcomes)
-#                 if u >= self.ufun.reserved_value
-#             ]
-#             # print(self._outcomes)
-
-#             # for _ in outcomes:
-#             #     if (float(self.ufun(_)) + float(self.opponent_ufun(_)) >= min_nash[0] + min_nash[1]):
-#             #         if( _ not in self._outcomes):
-#             #             self._outcomes.append(_)
-
-
-#             # self._rational = sorted(
-#             #     [
-#             #         (my_util, opp_util, _)
-#             #         for _ in self._outcomes
-#             #         if (my_util := float(self.ufun(_))) > 0
-#             #         and (opp_util := float(self.opponent_ufun(_)))
-#             #         > 0
-#             #     ],
-#             # )
-   
-#             self._rational = sorted(
-#                 [
-#                     (my_util, opp_util, _)
-#                     for _ in self._outcomes
-#                     if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-#                     and (opp_util := float(self.opponent_ufun(_)))
-#                     > 0
-#                 ],
-#             )
-#             self.nidx = len(self._rational)-1
-#             # print(self.nidx)
-#         # If there are no rational outcomes (i.e. our estimate of the opponent rv is very wrogn),
-#         # then just revert to offering our top offer
-#         if not self._rational:
-#             return SAOResponse(ResponseType.REJECT_OFFER, self.ufun.best())
-#         # find our aspiration level (value between 0 and 1) the higher the higher utility we require
-#         asp = aspiration_function(state.relative_time, 1.0, 0.0, self.e)
-
-
-#         n_rational = len(self._rational)
-#         max_rational = n_rational - 1
-#         min_indx = max(0, min(max_rational, int(asp * max_rational)))
-
-#         asp = aspiration_function(state.relative_time, 1.0, self.ufun.reserved_value, self.e)
-#         while(self.nidx!=0):
-#             nextidx = max(self.nidx-1 , 0)
-#             if(self._rational[nextidx][0] > asp):
-#                 self.nidx = nextidx
-#             else:
-#                 break
-
-#         # kaiki
-#         # if self.opponent_times == [] or self.opponent_utilities == []:
-#         #     popt, pcov = curve_fit(aspiration_function, self.opponent_times , self.opponent_utilities,bounds=(0, [1.0, 1.0, 100.0]))
-#         #     self.opponent_ufun.reserved_value = popt[1] - 0.10
-
-#         # best_utill = 0
-#         # for _ in frontier_utils:
-#         #     my_util = _[0]
-#         #     opp_util = _[1]
-#         #     if(opp_util >= self.opponent_ufun.reserved_value):
-#         #         best_utill = max(best_utill,my_util)
-#         # asp = aspiration_function(state.relative_time, 1.0, best_utill, self.e)
-
-#         # self.nidx = max_rational
-#         # while(self.nidx!=0):
-#         #     nextidx = max(self.nidx-1 , 0)
-#         #     if(self._rational[nextidx][0] > asp):
-#         #         self.nidx = nextidx
-#         #     else:
-#         #         break
-
-#         min_indx = self.nidx
-        
-#         # find current stochasticity which goes down from the set level to zero linearly
-#         s = aspiration_function(state.relative_time, self.stochasticity, 0.0, 1.0)
-#         # find the index of the maximum utility we require based on stochasticity (going down over time)
-#         max_indx = max(0, min(int(min_indx + s * n_rational), max_rational))
-#         max_indx = max(0, min(int(min_indx + s * n_rational), max_rational))
-#         # offer an outcome in the selected range
-#         # indx = random.randint(min_indx, max_indx) if min_indx != max_indx else min_indx
-
-#         indx = self.nidx
-        
-#         outcome = self._rational[indx][-1]
-#         # print("outcome")
-#         # print(outcome)
-#         if(self.ufun(self._best) > self.ufun(outcome) and self.ufun(self._best) > self.ufun.reserved_value):
-#             outcome = self._best
-
-#         if(state.relative_time > 0.99 and self.ufun(self._best) > self.ufun.reserved_value):
-#             outcome = self._best
-#         return SAOResponse(ResponseType.REJECT_OFFER, outcome)
-
-#     def is_acceptable(self, state: SAOState) -> bool:
-#         # The acceptance strategy
-#         assert self.ufun and self.opponent_ufun
-#         # get the offer from the mechanism state
-#         offer = state.current_offer
-#         # If there is no offer, there is nothing to accept
-#         if offer is None:
-#             return False
-#         self.opponent_times.append(state.relative_time)
-#         self.opponent_utilities.append(self.opponent_ufun(offer))
-        
-#         # print("offer")
-#         # print(offer)
-        
-#         if self._best is None:
-#             self._best = offer
-#         else:
-#             if(self.ufun(offer) > self.ufun(self._best)):
-#                 # print(self.ufun(offer))
-#                 # print(self.ufun(self._best))
-#                 self._best = offer
-#             elif(self.ufun(offer) == self.ufun(self._best)):
-#                 if(self.opponent_ufun(offer) < self.opponent_ufun(self._best)):
-#                     self._best = offer
-                    
-#         # Find the current aspiration level
-#         asp = aspiration_function(
-#             state.relative_time, 1.0, self.ufun.reserved_value, self.e
-#         )
-#         # accept if the utility of the received offer is higher than
-#         # the current aspiration
-
-#         return float(self.ufun(offer)) >= asp
-
-#     def update_reserved_value(self, state: SAOState):
-#         # Learns the reserved value of the partner
-#         assert self.opponent_ufun is not None
-#         # extract the current offer from the state
-#         offer = state.current_offer
-#         if offer is None:
-#             return
-#         # save to the list of utilities received from the opponent and their times
-#         self.opponent_utilities.append(float(self.opponent_ufun(offer)))
-#         self.opponent_times.append(state.relative_time)
-
-#         # If we do not have enough data, just assume that the opponent
-#         # reserved value is zero
-#         n_unique = len(set(self.opponent_utilities))
-#         if n_unique < self.min_unique_utilities:
-#             self._past_oppnent_rv = 0.0
-#             self.opponent_ufun.reserved_value = 0.0
-#             return
-#         # Use curve fitting to estimate the opponent reserved value
-#         # We assume the following:
-#         # - The opponent is using a concession strategy with an exponent between 0.2, 5.0
-#         # - The opponent never offers outcomes lower than their reserved value which means
-#         #   that their rv must be no higher than the worst outcome they offered for themselves.
-#         bounds = ((0.2, 0.0), (5.0, min(self.opponent_utilities)))
-#         err = ""
-#         try:
-#             optimal_vals, _ = curve_fit(
-#                 lambda x, e, rv: aspiration_function(
-#                     x, self.opponent_utilities[0], rv, e
-#                 ),
-#                 self.opponent_times,
-#                 self.opponent_utilities,
-#                 bounds=bounds,
-#             )
-#             self._past_oppnent_rv = self.opponent_ufun.reserved_value
-#             self.opponent_ufun.reserved_value = optimal_vals[1]
-#         except Exception as e:
-#             err, optimal_vals = f"{str(e)}", [None, None]
-
-#         # log my estimate
-#         if self._enable_logging:
-#             self.nmi.log_info(
-#                 self.id,
-#                 dict(
-#                     estimated_rv=self.opponent_ufun.reserved_value,
-#                     n_unique=n_unique,
-#                     opponent_utility=self.opponent_utilities[-1],
-#                     estimated_exponent=optimal_vals[0],
-#                     estimated_max=self.opponent_utilities[0],
-#                     error=err,
-#                 ),
-#             )
-
-
-
+        return float(self.ufun(offer)) >= myasp
 
 
 class Shochan_base75(SAONegotiator):
@@ -3403,9 +528,9 @@ class Shochan_base75(SAONegotiator):
         self._nash_factor = nash_factor
         self._best: Outcome = None  # type: ignore
         self.nidx = 0
+        assert self.opponent_ufun
         self.opponent_ufun.reserved_value = 0.0
         # self.most
-        
 
     def __call__(self, state: SAOState) -> SAOResponse:
         assert self.ufun and self.opponent_ufun
@@ -3418,15 +543,21 @@ class Shochan_base75(SAONegotiator):
             # print(self.opponent_ufun.reserved_value)
             return SAOResponse(ResponseType.ACCEPT_OFFER, state.current_offer)
         else:
-            self.preoffer.append((self.ufun(state.current_offer),self.opponent_ufun(state.current_offer)))
+            self.preoffer.append(
+                (
+                    self.ufun(state.current_offer),
+                    self.opponent_ufun(state.current_offer),
+                )
+            )
         # The offering strategy
-            
+
         # nash
         ufuns = (self.ufun, self.opponent_ufun)
         # list all outcomes
+        assert self.ufun.outcome_space
         outcomes = list(self.ufun.outcome_space.enumerate_or_sample())
         # find the pareto-front and the nash point
-        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)
+        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)  # type: ignore
         frontier_outcomes = [outcomes[_] for _ in frontier_indices]
         my_frontier_utils = [_[0] for _ in frontier_utils]
         nash = nash_points(ufuns, frontier_utils)  # type: ignore
@@ -3441,13 +572,12 @@ class Shochan_base75(SAONegotiator):
         # self._min_acceptable = 0
         # Set the set of outcomes to offer from
 
-      
-        # self._outcomes = [
+        # self._outcomes = [ # type: ignore
         #     w
         #     for u, w in zip(my_frontier_utils, frontier_outcomes)
         #     if u >= self._min_acceptable
-        # ]        
-    
+        # ]
+
         # We only update our estimate of the rational list of outcomes if it is not set or
         # there is a change in estimated reserved value
         if (
@@ -3457,7 +587,7 @@ class Shochan_base75(SAONegotiator):
             # The rational set of outcomes sorted dependingly according to our utility function
             # and the opponent utility function (in that order).
             # self._rational = sorted(
-            #     [
+            #     [ # type: ignore
             #         (my_util, opp_util, _)
             #         for _ in self.nmi.outcome_space.enumerate_or_sample(
             #             levels=10, max_cardinality=100_000
@@ -3471,18 +601,20 @@ class Shochan_base75(SAONegotiator):
             b = set([])
             ori_outcomes = []
             tmp = sorted(
-                [
+                [  # type: ignore
                     (float(self.ufun(_)), float(self.opponent_ufun(_)), _)
                     for _ in outcomes
-                ],reverse=True
+                ],
+                reverse=True,
             )
 
             ori_outcomes2 = []
             tmp2 = sorted(
-                [
+                [  # type: ignore
                     (float(self.opponent_ufun(_)), float(self.ufun(_)), _)
                     for _ in outcomes
-                ],reverse=True
+                ],
+                reverse=True,
             )
             # print(tmp[20])
             # i = 0
@@ -3490,19 +622,19 @@ class Shochan_base75(SAONegotiator):
             for i in range(len(tmp)):
                 # print(i)
                 # print(tmp[i])
-                if(tmp[i][0] not in a):
+                if tmp[i][0] not in a:
                     a.add(tmp[i][0])
-                    if(tmp[i][0] >= self.ufun.reserved_value):
-                        ori_outcomes.append(tmp[i][-1]) 
+                    if tmp[i][0] >= self.ufun.reserved_value:
+                        ori_outcomes.append(tmp[i][-1])
 
             for i in range(len(tmp2)):
                 # print(i)
                 # print(tmp[i])
-                if(tmp2[i][0] not in b):
+                if tmp2[i][0] not in b:
                     b.add(tmp2[i][0])
-                    if(tmp2[i][0] >= self.ufun.reserved_value):
-                        ori_outcomes2.append(tmp2[i][-1]) 
-                        # print([tmp[i][0],tmp[i][1]])    
+                    if tmp2[i][0] >= self.ufun.reserved_value:
+                        ori_outcomes2.append(tmp2[i][-1])
+                        # print([tmp[i][0],tmp[i][1]])
                         # print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
             c = set(ori_outcomes)
             for i in ori_outcomes2:
@@ -3511,15 +643,14 @@ class Shochan_base75(SAONegotiator):
             self._outcomes = all_outcomes
             # print()
 
-            self._outcomes = [
+            self._outcomes = [  # type: ignore
                 w
                 for u, w in zip(my_frontier_utils, frontier_outcomes)
                 if u >= self.ufun.reserved_value
-            ]     
-
+            ]
 
             # self._rational = sorted(
-            #     [
+            #     [ # type: ignore
             #         (my_util, opp_util, _)
             #         for _ in self._outcomes
             #         if (my_util := float(self.ufun(_))) > 0
@@ -3528,15 +659,14 @@ class Shochan_base75(SAONegotiator):
             #     ],
             # )
             self._rational = sorted(
-                [
+                [  # type: ignore
                     (my_util, opp_util, _)
                     for _ in self._outcomes
                     if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-                    and (opp_util := float(self.opponent_ufun(_)))
-                    > 0
+                    and (opp_util := float(self.opponent_ufun(_))) > 0
                 ],
             )
-            self.nidx = len(self._rational)-1
+            self.nidx = len(self._rational) - 1
             # print(self.nidx)
         # If there are no rational outcomes (i.e. our estimate of the opponent rv is very wrogn),
         # then just revert to offering our top offer
@@ -3549,16 +679,18 @@ class Shochan_base75(SAONegotiator):
         max_rational = n_rational - 1
         min_indx = max(0, min(max_rational, int(asp * max_rational)))
 
-        asp = aspiration_function(state.relative_time, 1.0, self.ufun.reserved_value, self.e)
-        while(self.nidx!=0):
-            nextidx = max(self.nidx-1 , 0)
-            if(self._rational[nextidx][0] > asp):
+        asp = aspiration_function(
+            state.relative_time, 1.0, self.ufun.reserved_value, self.e
+        )
+        while self.nidx != 0:
+            nextidx = max(self.nidx - 1, 0)
+            if self._rational[nextidx][0] > asp:
                 self.nidx = nextidx
             else:
                 break
 
         min_indx = self.nidx
-        
+
         # find current stochasticity which goes down from the set level to zero linearly
         s = aspiration_function(state.relative_time, self.stochasticity, 0.0, 1.0)
         # find the index of the maximum utility we require based on stochasticity (going down over time)
@@ -3568,14 +700,20 @@ class Shochan_base75(SAONegotiator):
         # indx = random.randint(min_indx, max_indx) if min_indx != max_indx else min_indx
 
         indx = self.nidx
-        
+
         outcome = self._rational[indx][-1]
         # print("outcome")
         # print(outcome)
-        if(self.ufun(self._best) > self.ufun(outcome) and self.ufun(self._best) > self.ufun.reserved_value):
+        if (
+            self.ufun(self._best) > self.ufun(outcome)
+            and self.ufun(self._best) > self.ufun.reserved_value
+        ):
             outcome = self._best
 
-        if(state.relative_time > 0.98 and self.ufun(self._best) > self.ufun.reserved_value):
+        if (
+            state.relative_time > 0.98
+            and self.ufun(self._best) > self.ufun.reserved_value
+        ):
             outcome = self._best
         return SAOResponse(ResponseType.REJECT_OFFER, outcome)
 
@@ -3587,21 +725,21 @@ class Shochan_base75(SAONegotiator):
         # If there is no offer, there is nothing to accept
         if offer is None:
             return False
-        
+
         # print("offer")
         # print(offer)
-        
+
         if self._best is None:
             self._best = offer
         else:
-            if(self.ufun(offer) > self.ufun(self._best)):
+            if self.ufun(offer) > self.ufun(self._best):
                 # print(self.ufun(offer))
                 # print(self.ufun(self._best))
                 self._best = offer
-            elif(self.ufun(offer) == self.ufun(self._best)):
-                if(self.opponent_ufun(offer) < self.opponent_ufun(self._best)):
+            elif self.ufun(offer) == self.ufun(self._best):
+                if self.opponent_ufun(offer) < self.opponent_ufun(self._best):
                     self._best = offer
-                    
+
         # Find the current aspiration level
         asp = aspiration_function(
             state.relative_time, 1.0, self.ufun.reserved_value, self.e
@@ -3663,6 +801,7 @@ class Shochan_base75(SAONegotiator):
                     error=err,
                 ),
             )
+
 
 class Shochan_base50(SAONegotiator):
     """A simple negotiator that uses curve fitting to learn the reserved value.
@@ -3728,9 +867,9 @@ class Shochan_base50(SAONegotiator):
         self._nash_factor = nash_factor
         self._best: Outcome = None  # type: ignore
         self.nidx = 0
+        assert self.opponent_ufun
         self.opponent_ufun.reserved_value = 0.0
         # self.most
-        
 
     def __call__(self, state: SAOState) -> SAOResponse:
         assert self.ufun and self.opponent_ufun
@@ -3743,15 +882,21 @@ class Shochan_base50(SAONegotiator):
             # print(self.opponent_ufun.reserved_value)
             return SAOResponse(ResponseType.ACCEPT_OFFER, state.current_offer)
         else:
-            self.preoffer.append((self.ufun(state.current_offer),self.opponent_ufun(state.current_offer)))
+            self.preoffer.append(
+                (
+                    self.ufun(state.current_offer),
+                    self.opponent_ufun(state.current_offer),
+                )
+            )
         # The offering strategy
-            
+
         # nash
         ufuns = (self.ufun, self.opponent_ufun)
         # list all outcomes
+        assert self.ufun.outcome_space
         outcomes = list(self.ufun.outcome_space.enumerate_or_sample())
         # find the pareto-front and the nash point
-        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)
+        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)  # type: ignore
         frontier_outcomes = [outcomes[_] for _ in frontier_indices]
         my_frontier_utils = [_[0] for _ in frontier_utils]
         nash = nash_points(ufuns, frontier_utils)  # type: ignore
@@ -3766,13 +911,12 @@ class Shochan_base50(SAONegotiator):
         # self._min_acceptable = 0
         # Set the set of outcomes to offer from
 
-      
-        # self._outcomes = [
+        # self._outcomes = [ # type: ignore
         #     w
         #     for u, w in zip(my_frontier_utils, frontier_outcomes)
         #     if u >= self._min_acceptable
-        # ]        
-    
+        # ]
+
         # We only update our estimate of the rational list of outcomes if it is not set or
         # there is a change in estimated reserved value
         if (
@@ -3782,7 +926,7 @@ class Shochan_base50(SAONegotiator):
             # The rational set of outcomes sorted dependingly according to our utility function
             # and the opponent utility function (in that order).
             # self._rational = sorted(
-            #     [
+            #     [ # type: ignore
             #         (my_util, opp_util, _)
             #         for _ in self.nmi.outcome_space.enumerate_or_sample(
             #             levels=10, max_cardinality=100_000
@@ -3796,18 +940,20 @@ class Shochan_base50(SAONegotiator):
             b = set([])
             ori_outcomes = []
             tmp = sorted(
-                [
+                [  # type: ignore
                     (float(self.ufun(_)), float(self.opponent_ufun(_)), _)
                     for _ in outcomes
-                ],reverse=True
+                ],
+                reverse=True,
             )
 
             ori_outcomes2 = []
             tmp2 = sorted(
-                [
+                [  # type: ignore
                     (float(self.opponent_ufun(_)), float(self.ufun(_)), _)
                     for _ in outcomes
-                ],reverse=True
+                ],
+                reverse=True,
             )
             # print(tmp[20])
             # i = 0
@@ -3815,19 +961,19 @@ class Shochan_base50(SAONegotiator):
             for i in range(len(tmp)):
                 # print(i)
                 # print(tmp[i])
-                if(tmp[i][0] not in a):
+                if tmp[i][0] not in a:
                     a.add(tmp[i][0])
-                    if(tmp[i][0] >= self.ufun.reserved_value):
-                        ori_outcomes.append(tmp[i][-1]) 
+                    if tmp[i][0] >= self.ufun.reserved_value:
+                        ori_outcomes.append(tmp[i][-1])
 
             for i in range(len(tmp2)):
                 # print(i)
                 # print(tmp[i])
-                if(tmp2[i][0] not in b):
+                if tmp2[i][0] not in b:
                     b.add(tmp2[i][0])
-                    if(tmp2[i][0] >= self.ufun.reserved_value):
-                        ori_outcomes2.append(tmp2[i][-1]) 
-                        # print([tmp[i][0],tmp[i][1]])    
+                    if tmp2[i][0] >= self.ufun.reserved_value:
+                        ori_outcomes2.append(tmp2[i][-1])
+                        # print([tmp[i][0],tmp[i][1]])
                         # print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
             c = set(ori_outcomes)
             for i in ori_outcomes2:
@@ -3836,15 +982,14 @@ class Shochan_base50(SAONegotiator):
             self._outcomes = all_outcomes
             # print()
 
-            self._outcomes = [
+            self._outcomes = [  # type: ignore
                 w
                 for u, w in zip(my_frontier_utils, frontier_outcomes)
                 if u >= self.ufun.reserved_value
-            ]     
-
+            ]
 
             # self._rational = sorted(
-            #     [
+            #     [ # type: ignore
             #         (my_util, opp_util, _)
             #         for _ in self._outcomes
             #         if (my_util := float(self.ufun(_))) > 0
@@ -3853,15 +998,14 @@ class Shochan_base50(SAONegotiator):
             #     ],
             # )
             self._rational = sorted(
-                [
+                [  # type: ignore
                     (my_util, opp_util, _)
                     for _ in self._outcomes
                     if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-                    and (opp_util := float(self.opponent_ufun(_)))
-                    > 0
+                    and (opp_util := float(self.opponent_ufun(_))) > 0
                 ],
             )
-            self.nidx = len(self._rational)-1
+            self.nidx = len(self._rational) - 1
             # print(self.nidx)
         # If there are no rational outcomes (i.e. our estimate of the opponent rv is very wrogn),
         # then just revert to offering our top offer
@@ -3874,16 +1018,18 @@ class Shochan_base50(SAONegotiator):
         max_rational = n_rational - 1
         min_indx = max(0, min(max_rational, int(asp * max_rational)))
 
-        asp = aspiration_function(state.relative_time, 1.0, self.ufun.reserved_value, self.e)
-        while(self.nidx!=0):
-            nextidx = max(self.nidx-1 , 0)
-            if(self._rational[nextidx][0] > asp):
+        asp = aspiration_function(
+            state.relative_time, 1.0, self.ufun.reserved_value, self.e
+        )
+        while self.nidx != 0:
+            nextidx = max(self.nidx - 1, 0)
+            if self._rational[nextidx][0] > asp:
                 self.nidx = nextidx
             else:
                 break
 
         min_indx = self.nidx
-        
+
         # find current stochasticity which goes down from the set level to zero linearly
         s = aspiration_function(state.relative_time, self.stochasticity, 0.0, 1.0)
         # find the index of the maximum utility we require based on stochasticity (going down over time)
@@ -3893,14 +1039,20 @@ class Shochan_base50(SAONegotiator):
         # indx = random.randint(min_indx, max_indx) if min_indx != max_indx else min_indx
 
         indx = self.nidx
-        
+
         outcome = self._rational[indx][-1]
         # print("outcome")
         # print(outcome)
-        if(self.ufun(self._best) > self.ufun(outcome) and self.ufun(self._best) > self.ufun.reserved_value):
+        if (
+            self.ufun(self._best) > self.ufun(outcome)
+            and self.ufun(self._best) > self.ufun.reserved_value
+        ):
             outcome = self._best
 
-        if(state.relative_time > 0.98 and self.ufun(self._best) > self.ufun.reserved_value):
+        if (
+            state.relative_time > 0.98
+            and self.ufun(self._best) > self.ufun.reserved_value
+        ):
             outcome = self._best
         return SAOResponse(ResponseType.REJECT_OFFER, outcome)
 
@@ -3912,21 +1064,21 @@ class Shochan_base50(SAONegotiator):
         # If there is no offer, there is nothing to accept
         if offer is None:
             return False
-        
+
         # print("offer")
         # print(offer)
-        
+
         if self._best is None:
             self._best = offer
         else:
-            if(self.ufun(offer) > self.ufun(self._best)):
+            if self.ufun(offer) > self.ufun(self._best):
                 # print(self.ufun(offer))
                 # print(self.ufun(self._best))
                 self._best = offer
-            elif(self.ufun(offer) == self.ufun(self._best)):
-                if(self.opponent_ufun(offer) < self.opponent_ufun(self._best)):
+            elif self.ufun(offer) == self.ufun(self._best):
+                if self.opponent_ufun(offer) < self.opponent_ufun(self._best):
                     self._best = offer
-                    
+
         # Find the current aspiration level
         asp = aspiration_function(
             state.relative_time, 1.0, self.ufun.reserved_value, self.e
@@ -3988,6 +1140,7 @@ class Shochan_base50(SAONegotiator):
                     error=err,
                 ),
             )
+
 
 class Shochan_base100(SAONegotiator):
     """A simple negotiator that uses curve fitting to learn the reserved value.
@@ -4053,9 +1206,9 @@ class Shochan_base100(SAONegotiator):
         self._nash_factor = nash_factor
         self._best: Outcome = None  # type: ignore
         self.nidx = 0
+        assert self.opponent_ufun
         self.opponent_ufun.reserved_value = 0.0
         # self.most
-        
 
     def __call__(self, state: SAOState) -> SAOResponse:
         assert self.ufun and self.opponent_ufun
@@ -4068,15 +1221,21 @@ class Shochan_base100(SAONegotiator):
             # print(self.opponent_ufun.reserved_value)
             return SAOResponse(ResponseType.ACCEPT_OFFER, state.current_offer)
         else:
-            self.preoffer.append((self.ufun(state.current_offer),self.opponent_ufun(state.current_offer)))
+            self.preoffer.append(
+                (
+                    self.ufun(state.current_offer),
+                    self.opponent_ufun(state.current_offer),
+                )
+            )
         # The offering strategy
-            
+
         # nash
         ufuns = (self.ufun, self.opponent_ufun)
         # list all outcomes
+        assert self.ufun.outcome_space
         outcomes = list(self.ufun.outcome_space.enumerate_or_sample())
         # find the pareto-front and the nash point
-        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)
+        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)  # type: ignore
         frontier_outcomes = [outcomes[_] for _ in frontier_indices]
         my_frontier_utils = [_[0] for _ in frontier_utils]
         nash = nash_points(ufuns, frontier_utils)  # type: ignore
@@ -4091,13 +1250,12 @@ class Shochan_base100(SAONegotiator):
         # self._min_acceptable = 0
         # Set the set of outcomes to offer from
 
-      
-        # self._outcomes = [
+        # self._outcomes = [ # type: ignore
         #     w
         #     for u, w in zip(my_frontier_utils, frontier_outcomes)
         #     if u >= self._min_acceptable
-        # ]        
-    
+        # ]
+
         # We only update our estimate of the rational list of outcomes if it is not set or
         # there is a change in estimated reserved value
         if (
@@ -4107,7 +1265,7 @@ class Shochan_base100(SAONegotiator):
             # The rational set of outcomes sorted dependingly according to our utility function
             # and the opponent utility function (in that order).
             # self._rational = sorted(
-            #     [
+            #     [ # type: ignore
             #         (my_util, opp_util, _)
             #         for _ in self.nmi.outcome_space.enumerate_or_sample(
             #             levels=10, max_cardinality=100_000
@@ -4121,18 +1279,20 @@ class Shochan_base100(SAONegotiator):
             b = set([])
             ori_outcomes = []
             tmp = sorted(
-                [
+                [  # type: ignore
                     (float(self.ufun(_)), float(self.opponent_ufun(_)), _)
                     for _ in outcomes
-                ],reverse=True
+                ],
+                reverse=True,
             )
 
             ori_outcomes2 = []
             tmp2 = sorted(
-                [
+                [  # type: ignore
                     (float(self.opponent_ufun(_)), float(self.ufun(_)), _)
                     for _ in outcomes
-                ],reverse=True
+                ],
+                reverse=True,
             )
             # print(tmp[20])
             # i = 0
@@ -4140,19 +1300,19 @@ class Shochan_base100(SAONegotiator):
             for i in range(len(tmp)):
                 # print(i)
                 # print(tmp[i])
-                if(tmp[i][0] not in a):
+                if tmp[i][0] not in a:
                     a.add(tmp[i][0])
-                    if(tmp[i][0] >= self.ufun.reserved_value):
-                        ori_outcomes.append(tmp[i][-1]) 
+                    if tmp[i][0] >= self.ufun.reserved_value:
+                        ori_outcomes.append(tmp[i][-1])
 
             for i in range(len(tmp2)):
                 # print(i)
                 # print(tmp[i])
-                if(tmp2[i][0] not in b):
+                if tmp2[i][0] not in b:
                     b.add(tmp2[i][0])
-                    if(tmp2[i][0] >= self.ufun.reserved_value):
-                        ori_outcomes2.append(tmp2[i][-1]) 
-                        # print([tmp[i][0],tmp[i][1]])    
+                    if tmp2[i][0] >= self.ufun.reserved_value:
+                        ori_outcomes2.append(tmp2[i][-1])
+                        # print([tmp[i][0],tmp[i][1]])
                         # print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
             c = set(ori_outcomes)
             for i in ori_outcomes2:
@@ -4161,15 +1321,14 @@ class Shochan_base100(SAONegotiator):
             self._outcomes = all_outcomes
             # print()
 
-            self._outcomes = [
+            self._outcomes = [  # type: ignore
                 w
                 for u, w in zip(my_frontier_utils, frontier_outcomes)
                 if u >= self.ufun.reserved_value
-            ]     
-
+            ]
 
             # self._rational = sorted(
-            #     [
+            #     [ # type: ignore
             #         (my_util, opp_util, _)
             #         for _ in self._outcomes
             #         if (my_util := float(self.ufun(_))) > 0
@@ -4178,15 +1337,14 @@ class Shochan_base100(SAONegotiator):
             #     ],
             # )
             self._rational = sorted(
-                [
+                [  # type: ignore
                     (my_util, opp_util, _)
                     for _ in self._outcomes
                     if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-                    and (opp_util := float(self.opponent_ufun(_)))
-                    > 0
+                    and (opp_util := float(self.opponent_ufun(_))) > 0
                 ],
             )
-            self.nidx = len(self._rational)-1
+            self.nidx = len(self._rational) - 1
             # print(self.nidx)
         # If there are no rational outcomes (i.e. our estimate of the opponent rv is very wrogn),
         # then just revert to offering our top offer
@@ -4199,16 +1357,18 @@ class Shochan_base100(SAONegotiator):
         max_rational = n_rational - 1
         min_indx = max(0, min(max_rational, int(asp * max_rational)))
 
-        asp = aspiration_function(state.relative_time, 1.0, self.ufun.reserved_value, self.e)
-        while(self.nidx!=0):
-            nextidx = max(self.nidx-1 , 0)
-            if(self._rational[nextidx][0] > asp):
+        asp = aspiration_function(
+            state.relative_time, 1.0, self.ufun.reserved_value, self.e
+        )
+        while self.nidx != 0:
+            nextidx = max(self.nidx - 1, 0)
+            if self._rational[nextidx][0] > asp:
                 self.nidx = nextidx
             else:
                 break
 
         min_indx = self.nidx
-        
+
         # find current stochasticity which goes down from the set level to zero linearly
         s = aspiration_function(state.relative_time, self.stochasticity, 0.0, 1.0)
         # find the index of the maximum utility we require based on stochasticity (going down over time)
@@ -4218,14 +1378,20 @@ class Shochan_base100(SAONegotiator):
         # indx = random.randint(min_indx, max_indx) if min_indx != max_indx else min_indx
 
         indx = self.nidx
-        
+
         outcome = self._rational[indx][-1]
         # print("outcome")
         # print(outcome)
-        if(self.ufun(self._best) > self.ufun(outcome) and self.ufun(self._best) > self.ufun.reserved_value):
+        if (
+            self.ufun(self._best) > self.ufun(outcome)
+            and self.ufun(self._best) > self.ufun.reserved_value
+        ):
             outcome = self._best
 
-        if(state.relative_time > 0.98 and self.ufun(self._best) > self.ufun.reserved_value):
+        if (
+            state.relative_time > 0.98
+            and self.ufun(self._best) > self.ufun.reserved_value
+        ):
             outcome = self._best
         return SAOResponse(ResponseType.REJECT_OFFER, outcome)
 
@@ -4237,21 +1403,21 @@ class Shochan_base100(SAONegotiator):
         # If there is no offer, there is nothing to accept
         if offer is None:
             return False
-        
+
         # print("offer")
         # print(offer)
-        
+
         if self._best is None:
             self._best = offer
         else:
-            if(self.ufun(offer) > self.ufun(self._best)):
+            if self.ufun(offer) > self.ufun(self._best):
                 # print(self.ufun(offer))
                 # print(self.ufun(self._best))
                 self._best = offer
-            elif(self.ufun(offer) == self.ufun(self._best)):
-                if(self.opponent_ufun(offer) < self.opponent_ufun(self._best)):
+            elif self.ufun(offer) == self.ufun(self._best):
+                if self.opponent_ufun(offer) < self.opponent_ufun(self._best):
                     self._best = offer
-                    
+
         # Find the current aspiration level
         asp = aspiration_function(
             state.relative_time, 1.0, self.ufun.reserved_value, self.e
@@ -4313,6 +1479,7 @@ class Shochan_base100(SAONegotiator):
                     error=err,
                 ),
             )
+
 
 class Shochan_base125(SAONegotiator):
     """A simple negotiator that uses curve fitting to learn the reserved value.
@@ -4378,9 +1545,9 @@ class Shochan_base125(SAONegotiator):
         self._nash_factor = nash_factor
         self._best: Outcome = None  # type: ignore
         self.nidx = 0
+        assert self.opponent_ufun
         self.opponent_ufun.reserved_value = 0.0
         # self.most
-        
 
     def __call__(self, state: SAOState) -> SAOResponse:
         assert self.ufun and self.opponent_ufun
@@ -4393,15 +1560,21 @@ class Shochan_base125(SAONegotiator):
             # print(self.opponent_ufun.reserved_value)
             return SAOResponse(ResponseType.ACCEPT_OFFER, state.current_offer)
         else:
-            self.preoffer.append((self.ufun(state.current_offer),self.opponent_ufun(state.current_offer)))
+            self.preoffer.append(
+                (
+                    self.ufun(state.current_offer),
+                    self.opponent_ufun(state.current_offer),
+                )
+            )
         # The offering strategy
-            
+
         # nash
         ufuns = (self.ufun, self.opponent_ufun)
         # list all outcomes
+        assert self.ufun.outcome_space
         outcomes = list(self.ufun.outcome_space.enumerate_or_sample())
         # find the pareto-front and the nash point
-        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)
+        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)  # type: ignore
         frontier_outcomes = [outcomes[_] for _ in frontier_indices]
         my_frontier_utils = [_[0] for _ in frontier_utils]
         nash = nash_points(ufuns, frontier_utils)  # type: ignore
@@ -4416,13 +1589,12 @@ class Shochan_base125(SAONegotiator):
         # self._min_acceptable = 0
         # Set the set of outcomes to offer from
 
-      
-        # self._outcomes = [
+        # self._outcomes = [ # type: ignore
         #     w
         #     for u, w in zip(my_frontier_utils, frontier_outcomes)
         #     if u >= self._min_acceptable
-        # ]        
-    
+        # ]
+
         # We only update our estimate of the rational list of outcomes if it is not set or
         # there is a change in estimated reserved value
         if (
@@ -4432,7 +1604,7 @@ class Shochan_base125(SAONegotiator):
             # The rational set of outcomes sorted dependingly according to our utility function
             # and the opponent utility function (in that order).
             # self._rational = sorted(
-            #     [
+            #     [ # type: ignore
             #         (my_util, opp_util, _)
             #         for _ in self.nmi.outcome_space.enumerate_or_sample(
             #             levels=10, max_cardinality=100_000
@@ -4446,18 +1618,20 @@ class Shochan_base125(SAONegotiator):
             b = set([])
             ori_outcomes = []
             tmp = sorted(
-                [
+                [  # type: ignore
                     (float(self.ufun(_)), float(self.opponent_ufun(_)), _)
                     for _ in outcomes
-                ],reverse=True
+                ],
+                reverse=True,
             )
 
             ori_outcomes2 = []
             tmp2 = sorted(
-                [
+                [  # type: ignore
                     (float(self.opponent_ufun(_)), float(self.ufun(_)), _)
                     for _ in outcomes
-                ],reverse=True
+                ],
+                reverse=True,
             )
             # print(tmp[20])
             # i = 0
@@ -4465,19 +1639,19 @@ class Shochan_base125(SAONegotiator):
             for i in range(len(tmp)):
                 # print(i)
                 # print(tmp[i])
-                if(tmp[i][0] not in a):
+                if tmp[i][0] not in a:
                     a.add(tmp[i][0])
-                    if(tmp[i][0] >= self.ufun.reserved_value):
-                        ori_outcomes.append(tmp[i][-1]) 
+                    if tmp[i][0] >= self.ufun.reserved_value:
+                        ori_outcomes.append(tmp[i][-1])
 
             for i in range(len(tmp2)):
                 # print(i)
                 # print(tmp[i])
-                if(tmp2[i][0] not in b):
+                if tmp2[i][0] not in b:
                     b.add(tmp2[i][0])
-                    if(tmp2[i][0] >= self.ufun.reserved_value):
-                        ori_outcomes2.append(tmp2[i][-1]) 
-                        # print([tmp[i][0],tmp[i][1]])    
+                    if tmp2[i][0] >= self.ufun.reserved_value:
+                        ori_outcomes2.append(tmp2[i][-1])
+                        # print([tmp[i][0],tmp[i][1]])
                         # print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
             c = set(ori_outcomes)
             for i in ori_outcomes2:
@@ -4486,15 +1660,14 @@ class Shochan_base125(SAONegotiator):
             self._outcomes = all_outcomes
             # print()
 
-            self._outcomes = [
+            self._outcomes = [  # type: ignore
                 w
                 for u, w in zip(my_frontier_utils, frontier_outcomes)
                 if u >= self.ufun.reserved_value
-            ]     
-
+            ]
 
             # self._rational = sorted(
-            #     [
+            #     [ # type: ignore
             #         (my_util, opp_util, _)
             #         for _ in self._outcomes
             #         if (my_util := float(self.ufun(_))) > 0
@@ -4503,15 +1676,14 @@ class Shochan_base125(SAONegotiator):
             #     ],
             # )
             self._rational = sorted(
-                [
+                [  # type: ignore
                     (my_util, opp_util, _)
                     for _ in self._outcomes
                     if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-                    and (opp_util := float(self.opponent_ufun(_)))
-                    > 0
+                    and (opp_util := float(self.opponent_ufun(_))) > 0
                 ],
             )
-            self.nidx = len(self._rational)-1
+            self.nidx = len(self._rational) - 1
             # print(self.nidx)
         # If there are no rational outcomes (i.e. our estimate of the opponent rv is very wrogn),
         # then just revert to offering our top offer
@@ -4524,16 +1696,18 @@ class Shochan_base125(SAONegotiator):
         max_rational = n_rational - 1
         min_indx = max(0, min(max_rational, int(asp * max_rational)))
 
-        asp = aspiration_function(state.relative_time, 1.0, self.ufun.reserved_value, self.e)
-        while(self.nidx!=0):
-            nextidx = max(self.nidx-1 , 0)
-            if(self._rational[nextidx][0] > asp):
+        asp = aspiration_function(
+            state.relative_time, 1.0, self.ufun.reserved_value, self.e
+        )
+        while self.nidx != 0:
+            nextidx = max(self.nidx - 1, 0)
+            if self._rational[nextidx][0] > asp:
                 self.nidx = nextidx
             else:
                 break
 
         min_indx = self.nidx
-        
+
         # find current stochasticity which goes down from the set level to zero linearly
         s = aspiration_function(state.relative_time, self.stochasticity, 0.0, 1.0)
         # find the index of the maximum utility we require based on stochasticity (going down over time)
@@ -4543,14 +1717,20 @@ class Shochan_base125(SAONegotiator):
         # indx = random.randint(min_indx, max_indx) if min_indx != max_indx else min_indx
 
         indx = self.nidx
-        
+
         outcome = self._rational[indx][-1]
         # print("outcome")
         # print(outcome)
-        if(self.ufun(self._best) > self.ufun(outcome) and self.ufun(self._best) > self.ufun.reserved_value):
+        if (
+            self.ufun(self._best) > self.ufun(outcome)
+            and self.ufun(self._best) > self.ufun.reserved_value
+        ):
             outcome = self._best
 
-        if(state.relative_time > 0.98 and self.ufun(self._best) > self.ufun.reserved_value):
+        if (
+            state.relative_time > 0.98
+            and self.ufun(self._best) > self.ufun.reserved_value
+        ):
             outcome = self._best
         return SAOResponse(ResponseType.REJECT_OFFER, outcome)
 
@@ -4562,21 +1742,21 @@ class Shochan_base125(SAONegotiator):
         # If there is no offer, there is nothing to accept
         if offer is None:
             return False
-        
+
         # print("offer")
         # print(offer)
-        
+
         if self._best is None:
             self._best = offer
         else:
-            if(self.ufun(offer) > self.ufun(self._best)):
+            if self.ufun(offer) > self.ufun(self._best):
                 # print(self.ufun(offer))
                 # print(self.ufun(self._best))
                 self._best = offer
-            elif(self.ufun(offer) == self.ufun(self._best)):
-                if(self.opponent_ufun(offer) < self.opponent_ufun(self._best)):
+            elif self.ufun(offer) == self.ufun(self._best):
+                if self.opponent_ufun(offer) < self.opponent_ufun(self._best):
                     self._best = offer
-                    
+
         # Find the current aspiration level
         asp = aspiration_function(
             state.relative_time, 1.0, self.ufun.reserved_value, self.e
@@ -4638,6 +1818,7 @@ class Shochan_base125(SAONegotiator):
                     error=err,
                 ),
             )
+
 
 class Shochan_base150(SAONegotiator):
     """A simple negotiator that uses curve fitting to learn the reserved value.
@@ -4703,9 +1884,9 @@ class Shochan_base150(SAONegotiator):
         self._nash_factor = nash_factor
         self._best: Outcome = None  # type: ignore
         self.nidx = 0
+        assert self.opponent_ufun
         self.opponent_ufun.reserved_value = 0.0
         # self.most
-        
 
     def __call__(self, state: SAOState) -> SAOResponse:
         assert self.ufun and self.opponent_ufun
@@ -4718,15 +1899,21 @@ class Shochan_base150(SAONegotiator):
             # print(self.opponent_ufun.reserved_value)
             return SAOResponse(ResponseType.ACCEPT_OFFER, state.current_offer)
         else:
-            self.preoffer.append((self.ufun(state.current_offer),self.opponent_ufun(state.current_offer)))
+            self.preoffer.append(
+                (
+                    self.ufun(state.current_offer),
+                    self.opponent_ufun(state.current_offer),
+                )
+            )
         # The offering strategy
-            
+
         # nash
         ufuns = (self.ufun, self.opponent_ufun)
         # list all outcomes
+        assert self.ufun.outcome_space
         outcomes = list(self.ufun.outcome_space.enumerate_or_sample())
         # find the pareto-front and the nash point
-        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)
+        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)  # type: ignore
         frontier_outcomes = [outcomes[_] for _ in frontier_indices]
         my_frontier_utils = [_[0] for _ in frontier_utils]
         nash = nash_points(ufuns, frontier_utils)  # type: ignore
@@ -4741,13 +1928,12 @@ class Shochan_base150(SAONegotiator):
         # self._min_acceptable = 0
         # Set the set of outcomes to offer from
 
-      
-        # self._outcomes = [
+        # self._outcomes = [ # type: ignore
         #     w
         #     for u, w in zip(my_frontier_utils, frontier_outcomes)
         #     if u >= self._min_acceptable
-        # ]        
-    
+        # ]
+
         # We only update our estimate of the rational list of outcomes if it is not set or
         # there is a change in estimated reserved value
         if (
@@ -4757,7 +1943,7 @@ class Shochan_base150(SAONegotiator):
             # The rational set of outcomes sorted dependingly according to our utility function
             # and the opponent utility function (in that order).
             # self._rational = sorted(
-            #     [
+            #     [ # type: ignore
             #         (my_util, opp_util, _)
             #         for _ in self.nmi.outcome_space.enumerate_or_sample(
             #             levels=10, max_cardinality=100_000
@@ -4771,18 +1957,20 @@ class Shochan_base150(SAONegotiator):
             b = set([])
             ori_outcomes = []
             tmp = sorted(
-                [
+                [  # type: ignore
                     (float(self.ufun(_)), float(self.opponent_ufun(_)), _)
                     for _ in outcomes
-                ],reverse=True
+                ],
+                reverse=True,
             )
 
             ori_outcomes2 = []
             tmp2 = sorted(
-                [
+                [  # type: ignore
                     (float(self.opponent_ufun(_)), float(self.ufun(_)), _)
                     for _ in outcomes
-                ],reverse=True
+                ],
+                reverse=True,
             )
             # print(tmp[20])
             # i = 0
@@ -4790,19 +1978,19 @@ class Shochan_base150(SAONegotiator):
             for i in range(len(tmp)):
                 # print(i)
                 # print(tmp[i])
-                if(tmp[i][0] not in a):
+                if tmp[i][0] not in a:
                     a.add(tmp[i][0])
-                    if(tmp[i][0] >= self.ufun.reserved_value):
-                        ori_outcomes.append(tmp[i][-1]) 
+                    if tmp[i][0] >= self.ufun.reserved_value:
+                        ori_outcomes.append(tmp[i][-1])
 
             for i in range(len(tmp2)):
                 # print(i)
                 # print(tmp[i])
-                if(tmp2[i][0] not in b):
+                if tmp2[i][0] not in b:
                     b.add(tmp2[i][0])
-                    if(tmp2[i][0] >= self.ufun.reserved_value):
-                        ori_outcomes2.append(tmp2[i][-1]) 
-                        # print([tmp[i][0],tmp[i][1]])    
+                    if tmp2[i][0] >= self.ufun.reserved_value:
+                        ori_outcomes2.append(tmp2[i][-1])
+                        # print([tmp[i][0],tmp[i][1]])
                         # print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
             c = set(ori_outcomes)
             for i in ori_outcomes2:
@@ -4811,15 +1999,14 @@ class Shochan_base150(SAONegotiator):
             self._outcomes = all_outcomes
             # print()
 
-            self._outcomes = [
+            self._outcomes = [  # type: ignore
                 w
                 for u, w in zip(my_frontier_utils, frontier_outcomes)
                 if u >= self.ufun.reserved_value
-            ]     
-
+            ]
 
             # self._rational = sorted(
-            #     [
+            #     [ # type: ignore
             #         (my_util, opp_util, _)
             #         for _ in self._outcomes
             #         if (my_util := float(self.ufun(_))) > 0
@@ -4828,15 +2015,14 @@ class Shochan_base150(SAONegotiator):
             #     ],
             # )
             self._rational = sorted(
-                [
+                [  # type: ignore
                     (my_util, opp_util, _)
                     for _ in self._outcomes
                     if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-                    and (opp_util := float(self.opponent_ufun(_)))
-                    > 0
+                    and (opp_util := float(self.opponent_ufun(_))) > 0
                 ],
             )
-            self.nidx = len(self._rational)-1
+            self.nidx = len(self._rational) - 1
             # print(self.nidx)
         # If there are no rational outcomes (i.e. our estimate of the opponent rv is very wrogn),
         # then just revert to offering our top offer
@@ -4849,16 +2035,18 @@ class Shochan_base150(SAONegotiator):
         max_rational = n_rational - 1
         min_indx = max(0, min(max_rational, int(asp * max_rational)))
 
-        asp = aspiration_function(state.relative_time, 1.0, self.ufun.reserved_value, self.e)
-        while(self.nidx!=0):
-            nextidx = max(self.nidx-1 , 0)
-            if(self._rational[nextidx][0] > asp):
+        asp = aspiration_function(
+            state.relative_time, 1.0, self.ufun.reserved_value, self.e
+        )
+        while self.nidx != 0:
+            nextidx = max(self.nidx - 1, 0)
+            if self._rational[nextidx][0] > asp:
                 self.nidx = nextidx
             else:
                 break
 
         min_indx = self.nidx
-        
+
         # find current stochasticity which goes down from the set level to zero linearly
         s = aspiration_function(state.relative_time, self.stochasticity, 0.0, 1.0)
         # find the index of the maximum utility we require based on stochasticity (going down over time)
@@ -4868,14 +2056,20 @@ class Shochan_base150(SAONegotiator):
         # indx = random.randint(min_indx, max_indx) if min_indx != max_indx else min_indx
 
         indx = self.nidx
-        
+
         outcome = self._rational[indx][-1]
         # print("outcome")
         # print(outcome)
-        if(self.ufun(self._best) > self.ufun(outcome) and self.ufun(self._best) > self.ufun.reserved_value):
+        if (
+            self.ufun(self._best) > self.ufun(outcome)
+            and self.ufun(self._best) > self.ufun.reserved_value
+        ):
             outcome = self._best
 
-        if(state.relative_time > 0.98 and self.ufun(self._best) > self.ufun.reserved_value):
+        if (
+            state.relative_time > 0.98
+            and self.ufun(self._best) > self.ufun.reserved_value
+        ):
             outcome = self._best
         return SAOResponse(ResponseType.REJECT_OFFER, outcome)
 
@@ -4887,21 +2081,21 @@ class Shochan_base150(SAONegotiator):
         # If there is no offer, there is nothing to accept
         if offer is None:
             return False
-        
+
         # print("offer")
         # print(offer)
-        
+
         if self._best is None:
             self._best = offer
         else:
-            if(self.ufun(offer) > self.ufun(self._best)):
+            if self.ufun(offer) > self.ufun(self._best):
                 # print(self.ufun(offer))
                 # print(self.ufun(self._best))
                 self._best = offer
-            elif(self.ufun(offer) == self.ufun(self._best)):
-                if(self.opponent_ufun(offer) < self.opponent_ufun(self._best)):
+            elif self.ufun(offer) == self.ufun(self._best):
+                if self.opponent_ufun(offer) < self.opponent_ufun(self._best):
                     self._best = offer
-                    
+
         # Find the current aspiration level
         asp = aspiration_function(
             state.relative_time, 1.0, self.ufun.reserved_value, self.e
@@ -4963,6 +2157,7 @@ class Shochan_base150(SAONegotiator):
                     error=err,
                 ),
             )
+
 
 class Shochan_base175(SAONegotiator):
     """A simple negotiator that uses curve fitting to learn the reserved value.
@@ -5028,9 +2223,9 @@ class Shochan_base175(SAONegotiator):
         self._nash_factor = nash_factor
         self._best: Outcome = None  # type: ignore
         self.nidx = 0
+        assert self.opponent_ufun
         self.opponent_ufun.reserved_value = 0.0
         # self.most
-        
 
     def __call__(self, state: SAOState) -> SAOResponse:
         assert self.ufun and self.opponent_ufun
@@ -5043,15 +2238,21 @@ class Shochan_base175(SAONegotiator):
             # print(self.opponent_ufun.reserved_value)
             return SAOResponse(ResponseType.ACCEPT_OFFER, state.current_offer)
         else:
-            self.preoffer.append((self.ufun(state.current_offer),self.opponent_ufun(state.current_offer)))
+            self.preoffer.append(
+                (
+                    self.ufun(state.current_offer),
+                    self.opponent_ufun(state.current_offer),
+                )
+            )
         # The offering strategy
-            
+
         # nash
         ufuns = (self.ufun, self.opponent_ufun)
         # list all outcomes
+        assert self.ufun.outcome_space
         outcomes = list(self.ufun.outcome_space.enumerate_or_sample())
         # find the pareto-front and the nash point
-        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)
+        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)  # type: ignore
         frontier_outcomes = [outcomes[_] for _ in frontier_indices]
         my_frontier_utils = [_[0] for _ in frontier_utils]
         nash = nash_points(ufuns, frontier_utils)  # type: ignore
@@ -5066,13 +2267,12 @@ class Shochan_base175(SAONegotiator):
         # self._min_acceptable = 0
         # Set the set of outcomes to offer from
 
-      
-        # self._outcomes = [
+        # self._outcomes = [ # type: ignore
         #     w
         #     for u, w in zip(my_frontier_utils, frontier_outcomes)
         #     if u >= self._min_acceptable
-        # ]        
-    
+        # ]
+
         # We only update our estimate of the rational list of outcomes if it is not set or
         # there is a change in estimated reserved value
         if (
@@ -5082,7 +2282,7 @@ class Shochan_base175(SAONegotiator):
             # The rational set of outcomes sorted dependingly according to our utility function
             # and the opponent utility function (in that order).
             # self._rational = sorted(
-            #     [
+            #     [ # type: ignore
             #         (my_util, opp_util, _)
             #         for _ in self.nmi.outcome_space.enumerate_or_sample(
             #             levels=10, max_cardinality=100_000
@@ -5096,18 +2296,20 @@ class Shochan_base175(SAONegotiator):
             b = set([])
             ori_outcomes = []
             tmp = sorted(
-                [
+                [  # type: ignore
                     (float(self.ufun(_)), float(self.opponent_ufun(_)), _)
                     for _ in outcomes
-                ],reverse=True
+                ],
+                reverse=True,
             )
 
             ori_outcomes2 = []
             tmp2 = sorted(
-                [
+                [  # type: ignore
                     (float(self.opponent_ufun(_)), float(self.ufun(_)), _)
                     for _ in outcomes
-                ],reverse=True
+                ],
+                reverse=True,
             )
             # print(tmp[20])
             # i = 0
@@ -5115,19 +2317,19 @@ class Shochan_base175(SAONegotiator):
             for i in range(len(tmp)):
                 # print(i)
                 # print(tmp[i])
-                if(tmp[i][0] not in a):
+                if tmp[i][0] not in a:
                     a.add(tmp[i][0])
-                    if(tmp[i][0] >= self.ufun.reserved_value):
-                        ori_outcomes.append(tmp[i][-1]) 
+                    if tmp[i][0] >= self.ufun.reserved_value:
+                        ori_outcomes.append(tmp[i][-1])
 
             for i in range(len(tmp2)):
                 # print(i)
                 # print(tmp[i])
-                if(tmp2[i][0] not in b):
+                if tmp2[i][0] not in b:
                     b.add(tmp2[i][0])
-                    if(tmp2[i][0] >= self.ufun.reserved_value):
-                        ori_outcomes2.append(tmp2[i][-1]) 
-                        # print([tmp[i][0],tmp[i][1]])    
+                    if tmp2[i][0] >= self.ufun.reserved_value:
+                        ori_outcomes2.append(tmp2[i][-1])
+                        # print([tmp[i][0],tmp[i][1]])
                         # print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
             c = set(ori_outcomes)
             for i in ori_outcomes2:
@@ -5136,15 +2338,14 @@ class Shochan_base175(SAONegotiator):
             self._outcomes = all_outcomes
             # print()
 
-            self._outcomes = [
+            self._outcomes = [  # type: ignore
                 w
                 for u, w in zip(my_frontier_utils, frontier_outcomes)
                 if u >= self.ufun.reserved_value
-            ]     
-
+            ]
 
             # self._rational = sorted(
-            #     [
+            #     [ # type: ignore
             #         (my_util, opp_util, _)
             #         for _ in self._outcomes
             #         if (my_util := float(self.ufun(_))) > 0
@@ -5153,15 +2354,14 @@ class Shochan_base175(SAONegotiator):
             #     ],
             # )
             self._rational = sorted(
-                [
+                [  # type: ignore
                     (my_util, opp_util, _)
                     for _ in self._outcomes
                     if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-                    and (opp_util := float(self.opponent_ufun(_)))
-                    > 0
+                    and (opp_util := float(self.opponent_ufun(_))) > 0
                 ],
             )
-            self.nidx = len(self._rational)-1
+            self.nidx = len(self._rational) - 1
             # print(self.nidx)
         # If there are no rational outcomes (i.e. our estimate of the opponent rv is very wrogn),
         # then just revert to offering our top offer
@@ -5174,16 +2374,18 @@ class Shochan_base175(SAONegotiator):
         max_rational = n_rational - 1
         min_indx = max(0, min(max_rational, int(asp * max_rational)))
 
-        asp = aspiration_function(state.relative_time, 1.0, self.ufun.reserved_value, self.e)
-        while(self.nidx!=0):
-            nextidx = max(self.nidx-1 , 0)
-            if(self._rational[nextidx][0] > asp):
+        asp = aspiration_function(
+            state.relative_time, 1.0, self.ufun.reserved_value, self.e
+        )
+        while self.nidx != 0:
+            nextidx = max(self.nidx - 1, 0)
+            if self._rational[nextidx][0] > asp:
                 self.nidx = nextidx
             else:
                 break
 
         min_indx = self.nidx
-        
+
         # find current stochasticity which goes down from the set level to zero linearly
         s = aspiration_function(state.relative_time, self.stochasticity, 0.0, 1.0)
         # find the index of the maximum utility we require based on stochasticity (going down over time)
@@ -5193,14 +2395,20 @@ class Shochan_base175(SAONegotiator):
         # indx = random.randint(min_indx, max_indx) if min_indx != max_indx else min_indx
 
         indx = self.nidx
-        
+
         outcome = self._rational[indx][-1]
         # print("outcome")
         # print(outcome)
-        if(self.ufun(self._best) > self.ufun(outcome) and self.ufun(self._best) > self.ufun.reserved_value):
+        if (
+            self.ufun(self._best) > self.ufun(outcome)
+            and self.ufun(self._best) > self.ufun.reserved_value
+        ):
             outcome = self._best
 
-        if(state.relative_time > 0.98 and self.ufun(self._best) > self.ufun.reserved_value):
+        if (
+            state.relative_time > 0.98
+            and self.ufun(self._best) > self.ufun.reserved_value
+        ):
             outcome = self._best
         return SAOResponse(ResponseType.REJECT_OFFER, outcome)
 
@@ -5212,21 +2420,21 @@ class Shochan_base175(SAONegotiator):
         # If there is no offer, there is nothing to accept
         if offer is None:
             return False
-        
+
         # print("offer")
         # print(offer)
-        
+
         if self._best is None:
             self._best = offer
         else:
-            if(self.ufun(offer) > self.ufun(self._best)):
+            if self.ufun(offer) > self.ufun(self._best):
                 # print(self.ufun(offer))
                 # print(self.ufun(self._best))
                 self._best = offer
-            elif(self.ufun(offer) == self.ufun(self._best)):
-                if(self.opponent_ufun(offer) < self.opponent_ufun(self._best)):
+            elif self.ufun(offer) == self.ufun(self._best):
+                if self.opponent_ufun(offer) < self.opponent_ufun(self._best):
                     self._best = offer
-                    
+
         # Find the current aspiration level
         asp = aspiration_function(
             state.relative_time, 1.0, self.ufun.reserved_value, self.e
@@ -5288,6 +2496,7 @@ class Shochan_base175(SAONegotiator):
                     error=err,
                 ),
             )
+
 
 class Shochan_base200(SAONegotiator):
     """A simple negotiator that uses curve fitting to learn the reserved value.
@@ -5353,9 +2562,9 @@ class Shochan_base200(SAONegotiator):
         self._nash_factor = nash_factor
         self._best: Outcome = None  # type: ignore
         self.nidx = 0
+        assert self.opponent_ufun
         self.opponent_ufun.reserved_value = 0.0
         # self.most
-        
 
     def __call__(self, state: SAOState) -> SAOResponse:
         assert self.ufun and self.opponent_ufun
@@ -5368,15 +2577,21 @@ class Shochan_base200(SAONegotiator):
             # print(self.opponent_ufun.reserved_value)
             return SAOResponse(ResponseType.ACCEPT_OFFER, state.current_offer)
         else:
-            self.preoffer.append((self.ufun(state.current_offer),self.opponent_ufun(state.current_offer)))
+            self.preoffer.append(
+                (
+                    self.ufun(state.current_offer),
+                    self.opponent_ufun(state.current_offer),
+                )
+            )
         # The offering strategy
-            
+
         # nash
         ufuns = (self.ufun, self.opponent_ufun)
         # list all outcomes
+        assert self.ufun.outcome_space
         outcomes = list(self.ufun.outcome_space.enumerate_or_sample())
         # find the pareto-front and the nash point
-        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)
+        frontier_utils, frontier_indices = pareto_frontier(ufuns, outcomes)  # type: ignore
         frontier_outcomes = [outcomes[_] for _ in frontier_indices]
         my_frontier_utils = [_[0] for _ in frontier_utils]
         nash = nash_points(ufuns, frontier_utils)  # type: ignore
@@ -5391,13 +2606,12 @@ class Shochan_base200(SAONegotiator):
         # self._min_acceptable = 0
         # Set the set of outcomes to offer from
 
-      
-        # self._outcomes = [
+        # self._outcomes = [ # type: ignore
         #     w
         #     for u, w in zip(my_frontier_utils, frontier_outcomes)
         #     if u >= self._min_acceptable
-        # ]        
-    
+        # ]
+
         # We only update our estimate of the rational list of outcomes if it is not set or
         # there is a change in estimated reserved value
         if (
@@ -5407,7 +2621,7 @@ class Shochan_base200(SAONegotiator):
             # The rational set of outcomes sorted dependingly according to our utility function
             # and the opponent utility function (in that order).
             # self._rational = sorted(
-            #     [
+            #     [ # type: ignore
             #         (my_util, opp_util, _)
             #         for _ in self.nmi.outcome_space.enumerate_or_sample(
             #             levels=10, max_cardinality=100_000
@@ -5421,18 +2635,20 @@ class Shochan_base200(SAONegotiator):
             b = set([])
             ori_outcomes = []
             tmp = sorted(
-                [
+                [  # type: ignore
                     (float(self.ufun(_)), float(self.opponent_ufun(_)), _)
                     for _ in outcomes
-                ],reverse=True
+                ],
+                reverse=True,
             )
 
             ori_outcomes2 = []
             tmp2 = sorted(
-                [
+                [  # type: ignore
                     (float(self.opponent_ufun(_)), float(self.ufun(_)), _)
                     for _ in outcomes
-                ],reverse=True
+                ],
+                reverse=True,
             )
             # print(tmp[20])
             # i = 0
@@ -5440,19 +2656,19 @@ class Shochan_base200(SAONegotiator):
             for i in range(len(tmp)):
                 # print(i)
                 # print(tmp[i])
-                if(tmp[i][0] not in a):
+                if tmp[i][0] not in a:
                     a.add(tmp[i][0])
-                    if(tmp[i][0] >= self.ufun.reserved_value):
-                        ori_outcomes.append(tmp[i][-1]) 
+                    if tmp[i][0] >= self.ufun.reserved_value:
+                        ori_outcomes.append(tmp[i][-1])
 
             for i in range(len(tmp2)):
                 # print(i)
                 # print(tmp[i])
-                if(tmp2[i][0] not in b):
+                if tmp2[i][0] not in b:
                     b.add(tmp2[i][0])
-                    if(tmp2[i][0] >= self.ufun.reserved_value):
-                        ori_outcomes2.append(tmp2[i][-1]) 
-                        # print([tmp[i][0],tmp[i][1]])    
+                    if tmp2[i][0] >= self.ufun.reserved_value:
+                        ori_outcomes2.append(tmp2[i][-1])
+                        # print([tmp[i][0],tmp[i][1]])
                         # print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
             c = set(ori_outcomes)
             for i in ori_outcomes2:
@@ -5461,15 +2677,14 @@ class Shochan_base200(SAONegotiator):
             self._outcomes = all_outcomes
             # print()
 
-            self._outcomes = [
+            self._outcomes = [  # type: ignore
                 w
                 for u, w in zip(my_frontier_utils, frontier_outcomes)
                 if u >= self.ufun.reserved_value
-            ]     
-
+            ]
 
             # self._rational = sorted(
-            #     [
+            #     [ # type: ignore
             #         (my_util, opp_util, _)
             #         for _ in self._outcomes
             #         if (my_util := float(self.ufun(_))) > 0
@@ -5478,15 +2693,14 @@ class Shochan_base200(SAONegotiator):
             #     ],
             # )
             self._rational = sorted(
-                [
+                [  # type: ignore
                     (my_util, opp_util, _)
                     for _ in self._outcomes
                     if (my_util := float(self.ufun(_))) > self.ufun.reserved_value
-                    and (opp_util := float(self.opponent_ufun(_)))
-                    > 0
+                    and (opp_util := float(self.opponent_ufun(_))) > 0
                 ],
             )
-            self.nidx = len(self._rational)-1
+            self.nidx = len(self._rational) - 1
             # print(self.nidx)
         # If there are no rational outcomes (i.e. our estimate of the opponent rv is very wrogn),
         # then just revert to offering our top offer
@@ -5499,16 +2713,18 @@ class Shochan_base200(SAONegotiator):
         max_rational = n_rational - 1
         min_indx = max(0, min(max_rational, int(asp * max_rational)))
 
-        asp = aspiration_function(state.relative_time, 1.0, self.ufun.reserved_value, self.e)
-        while(self.nidx!=0):
-            nextidx = max(self.nidx-1 , 0)
-            if(self._rational[nextidx][0] > asp):
+        asp = aspiration_function(
+            state.relative_time, 1.0, self.ufun.reserved_value, self.e
+        )
+        while self.nidx != 0:
+            nextidx = max(self.nidx - 1, 0)
+            if self._rational[nextidx][0] > asp:
                 self.nidx = nextidx
             else:
                 break
 
         min_indx = self.nidx
-        
+
         # find current stochasticity which goes down from the set level to zero linearly
         s = aspiration_function(state.relative_time, self.stochasticity, 0.0, 1.0)
         # find the index of the maximum utility we require based on stochasticity (going down over time)
@@ -5518,14 +2734,20 @@ class Shochan_base200(SAONegotiator):
         # indx = random.randint(min_indx, max_indx) if min_indx != max_indx else min_indx
 
         indx = self.nidx
-        
+
         outcome = self._rational[indx][-1]
         # print("outcome")
         # print(outcome)
-        if(self.ufun(self._best) > self.ufun(outcome) and self.ufun(self._best) > self.ufun.reserved_value):
+        if (
+            self.ufun(self._best) > self.ufun(outcome)
+            and self.ufun(self._best) > self.ufun.reserved_value
+        ):
             outcome = self._best
 
-        if(state.relative_time > 0.98 and self.ufun(self._best) > self.ufun.reserved_value):
+        if (
+            state.relative_time > 0.98
+            and self.ufun(self._best) > self.ufun.reserved_value
+        ):
             outcome = self._best
         return SAOResponse(ResponseType.REJECT_OFFER, outcome)
 
@@ -5537,21 +2759,21 @@ class Shochan_base200(SAONegotiator):
         # If there is no offer, there is nothing to accept
         if offer is None:
             return False
-        
+
         # print("offer")
         # print(offer)
-        
+
         if self._best is None:
             self._best = offer
         else:
-            if(self.ufun(offer) > self.ufun(self._best)):
+            if self.ufun(offer) > self.ufun(self._best):
                 # print(self.ufun(offer))
                 # print(self.ufun(self._best))
                 self._best = offer
-            elif(self.ufun(offer) == self.ufun(self._best)):
-                if(self.opponent_ufun(offer) < self.opponent_ufun(self._best)):
+            elif self.ufun(offer) == self.ufun(self._best):
+                if self.opponent_ufun(offer) < self.opponent_ufun(self._best):
                     self._best = offer
-                    
+
         # Find the current aspiration level
         asp = aspiration_function(
             state.relative_time, 1.0, self.ufun.reserved_value, self.e
@@ -5613,4 +2835,3 @@ class Shochan_base200(SAONegotiator):
                     error=err,
                 ),
             )
-

--- a/src/anl_agents/anl2024/team_186/ilan.py
+++ b/src/anl_agents/anl2024/team_186/ilan.py
@@ -20,9 +20,15 @@ class Ilan(SAONegotiator):
         self._past_opponent_rv = 0.0
         self._rational = []
 
-    def on_session_starting(self):
-        super().on_session_starting()
-        self.total_rounds = self.session.n_steps
+    def on_negotiation_start(self, state):
+        super().on_negotiation_start(state)
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        self.total_rounds = nsteps__
 
     def __call__(self, state: SAOState) -> SAOResponse:
         self.update_reserved_value(state.current_offer, state.relative_time)
@@ -33,6 +39,7 @@ class Ilan(SAONegotiator):
         )
 
     def generate_offer(self, relative_time) -> Outcome:
+        assert self.ufun and self.opponent_ufun
         if (
             not self._rational
             or abs(self.opponent_ufun.reserved_value - self._past_opponent_rv) > 1e-3
@@ -58,12 +65,14 @@ class Ilan(SAONegotiator):
     def is_acceptable(self, offer, relative_time) -> bool:
         if offer is None:
             return False
+        assert self.ufun
         asp = (1.0 - np.power(relative_time, self.e)) + self.ufun.reserved_value
         return float(self.ufun(offer)) >= asp * 1.2
 
     def update_reserved_value(self, offer, relative_time):
         if offer is None:
             return
+        assert self.opponent_ufun
         self.opponents_utilities.append(float(self.opponent_ufun(offer)))
         self.opponent_times.append(relative_time)
         bounds = ((0.2, 0.0), (5.0, min(self.opponents_utilities)))

--- a/src/anl_agents/anl2024/team_191/func.py
+++ b/src/anl_agents/anl2024/team_191/func.py
@@ -25,11 +25,13 @@ def update_partner_reserved_value(self, state: SAOState) -> None:
 
     # Adjust std_dev to control the spread of the distribution
     # making it dynamic might not be optimal, need to test
-    std_dev = np.max(
-        np.array(
-            [(self.nmi.n_steps - self.current_step) / self.nmi.n_steps - 0.6, 0.05]
-        )
+
+    nsteps__ = (
+        self.nmi.n_steps
+        if self.nmi.n_steps
+        else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
     )
+    std_dev = np.max(np.array([(nsteps__ - self.current_step) / nsteps__ - 0.6, 0.05]))
 
     # Calculate bucket boundaries
     bucket_boundaries = np.linspace(0, 1, self.num_of_hyp + 1)
@@ -60,4 +62,3 @@ def update_partner_reserved_value(self, state: SAOState) -> None:
     self.partner_reserved_value = np.dot(
         self.probability_prev, self.opponents_reserved_value
     )
-

--- a/src/anl_agents/anl2024/team_191/inegotiator.py
+++ b/src/anl_agents/anl2024/team_191/inegotiator.py
@@ -34,6 +34,7 @@ class INegotiator(SAONegotiator):
             - We use it to save a list of all rational outcomes.
 
         """
+        _ = changes
         # If there a no outcomes (should in theory never happen)
         if self.ufun is None:
             return
@@ -61,7 +62,16 @@ class INegotiator(SAONegotiator):
         self.new_proposal = None
 
         min_number_hyp = 10
-        max_number_hyp = np.min([int(self.nmi.n_steps / 5), 100])
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        if nsteps__ is not None:
+            max_number_hyp = np.min([int(nsteps__ / 5), 100])
+        else:
+            max_number_hyp = 100
 
         self.num_of_hyp = np.max([min_number_hyp, max_number_hyp])
         segments = np.linspace(0, 1, num=self.num_of_hyp + 1)
@@ -132,7 +142,13 @@ class INegotiator(SAONegotiator):
             return False
 
         # We consider the last 3% of the negotation as the final offers, or the final round in smaller negotations
-        end_game = self.current_phase(state) == 2 or state.step + 1 == self.nmi.n_steps
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        end_game = self.current_phase(state) == 2 or state.step + 1 == nsteps__
         # In case we get significantly more utility than our reservation value in the end game, we accept
         if (
             end_game
@@ -165,8 +181,13 @@ class INegotiator(SAONegotiator):
         return np.argmin(dist_2)
 
     def current_phase(self, state):
-        percentage_complete = state.step / self.nmi.n_steps
-        steps_left = self.nmi.n_steps - state.step
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        percentage_complete = state.step / nsteps__
+        steps_left = nsteps__ - state.step
         min_endgame_steps = 5
         if percentage_complete < 0.89 and steps_left > min_endgame_steps:
             return 0
@@ -182,6 +203,7 @@ class INegotiator(SAONegotiator):
         least_lines = []
         line_segments = []
         points_with_distance = []
+        assert self.ufun and self.opponent_ufun
 
         a = [self.ufun(item) for item in self.rational_outcomes]
         b = [self.opponent_ufun(item) for item in self.rational_outcomes]
@@ -220,6 +242,7 @@ class INegotiator(SAONegotiator):
         return points_with_distance
 
     def bidding_initializations(self):
+        assert self.ufun and self.opponent_ufun
         for i in self.rational_outcomes:
             self.our_offers.append(
                 (self.ufun(i), self.opponent_ufun(i), self.rational_outcomes.index(i))
@@ -258,16 +281,17 @@ class INegotiator(SAONegotiator):
         # Get all possible offers
 
         # Variable init
-        opp_prev_opp_offer_val = self.opponent_ufun(self.own_previous_offer)
-        own_prev_offer_val = self.ufun(self.own_previous_offer)
+        assert self.ufun and self.opponent_ufun
+        opp_prev_opp_offer_val = float(self.opponent_ufun(self.own_previous_offer))
+        own_prev_offer_val = float(self.ufun(self.own_previous_offer))
 
         # calculate their movement
-        opp_prev_offer_val = self.opponent_ufun(self.prev_opp_offer)
-        opp_current_offer_val = self.opponent_ufun(state.current_offer)
+        opp_prev_offer_val = float(self.opponent_ufun(self.prev_opp_offer))
+        opp_current_offer_val = float(self.opponent_ufun(state.current_offer))
         opp_concession = opp_prev_offer_val - opp_current_offer_val
 
-        own_prev_opp_offer_val = self.ufun(self.prev_opp_offer)
-        own_curr_offer_val = self.ufun(state.current_offer)
+        own_prev_opp_offer_val = float(self.ufun(self.prev_opp_offer))
+        own_curr_offer_val = float(self.ufun(state.current_offer))
         opp_concession_for_us = own_prev_opp_offer_val - own_curr_offer_val
 
         if opp_concession > 0:
@@ -340,7 +364,7 @@ class INegotiator(SAONegotiator):
                     self.phase_2_flag = True
                     return self.bidding_strategy(state)
                 self.phase_2_flag = True
-                index = max_vers[2]
+                index = max_vers[2]  # type: ignore
                 self.own_previous_offer = self.rational_outcomes[index]
 
                 self.prev_opp_offer = state.current_offer
@@ -412,8 +436,9 @@ class INegotiator(SAONegotiator):
                     (self.ufun(i), self.opponent_ufun(i), final_outcomes.index(i))
                 )
             # get nash points
+            assert self.ufun and self.opponent_ufun
             nash = nash_points(
-                [self.ufun, self.opponent_ufun],
+                [self.ufun, self.opponent_ufun],  # type: ignore
                 pareto_points[0],
                 ranges=[(self.reserved_value, 1), (self.partner_reserved_value, 1)],
             )
@@ -422,7 +447,7 @@ class INegotiator(SAONegotiator):
                 # try to find any nash point if none are found by reducing the opp. RV incrementally
                 temp_opp_rv -= 0.01
                 nash = nash_points(
-                    [self.ufun, self.opponent_ufun],
+                    [self.ufun, self.opponent_ufun],  # type: ignore
                     pareto_points[0],
                     ranges=[(self.reserved_value, 1), (temp_opp_rv, 1)],
                 )
@@ -448,10 +473,22 @@ class INegotiator(SAONegotiator):
                 return self.rational_outcomes[index]
             else:
                 # get number of turns left
-                num_of_turns_left = self.nmi.n_steps - state.step
+
+                nsteps__ = (
+                    self.nmi.n_steps
+                    if self.nmi.n_steps
+                    else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+                )
+                if nsteps__ is None:
+                    num_of_turns_left = min(
+                        state.step * self.nmi.time_limit / state.time,
+                        self.nmi.n_outcomes,
+                    )
+                else:
+                    num_of_turns_left = nsteps__ - state.step
 
                 # move along pareto towards the nash to end there in the last step
-                move_distance = self.ufun(self.own_previous_offer)
+                move_distance = float(self.ufun(self.own_previous_offer))
                 # nudge towards the nash point
                 nudge = np.abs(nash[0][0][0] - move_distance) / num_of_turns_left
 
@@ -461,7 +498,9 @@ class INegotiator(SAONegotiator):
                 elif move_distance < nash[0][0][0]:
                     move_distance += nudge
 
-                inverse_move_distance = self.opponent_ufun(self.own_previous_offer)
+                inverse_move_distance = float(
+                    self.opponent_ufun(self.own_previous_offer)
+                )
                 nudge = (
                     np.abs(nash[0][0][1] - inverse_move_distance) / num_of_turns_left
                 )
@@ -503,9 +542,9 @@ class INegotiator(SAONegotiator):
             # compute opponent lambda using (7)
             log_base = self.current_step / (self.current_step - 1)
 
-            opp_offer_val = self.opponent_ufun(self.opp_offer)
-            opp_init_val = self.opponent_ufun(self.opponents_initial_proposal)
-            opp_prev_offer_val = self.opponent_ufun(self.prev_opp_offer)
+            opp_offer_val = float(self.opponent_ufun(self.opp_offer))
+            opp_init_val = float(self.opponent_ufun(self.opponents_initial_proposal))
+            opp_prev_offer_val = float(self.opponent_ufun(self.prev_opp_offer))
 
             if opp_offer_val > opp_init_val:
                 opp_offer_val = opp_init_val
@@ -529,7 +568,12 @@ class INegotiator(SAONegotiator):
                 lambda_opp = min([lambda_opp, 10**4])
 
             # compute discount factor using (10)
-            discount_ratio = np.power(self.current_step / self.nmi.n_steps, lambda_opp)
+            if self.nmi.n_steps is not None:
+                discount_ratio = np.power(
+                    self.current_step / self.nmi.n_steps, lambda_opp
+                )
+            else:
+                discount_ratio = np.power(state.relative_time, lambda_opp)
             if discount_ratio < 1e-6 or math.isnan(discount_ratio):
                 discount_ratio = 1e-6
 
@@ -551,9 +595,9 @@ class INegotiator(SAONegotiator):
                 for i in range(num_buckets):
                     lower_bound = bucket_boundaries[i]
                     upper_bound = bucket_boundaries[i + 1]
-                    probability = scipy.stats.norm.cdf(
+                    probability = scipy.stats.norm.cdf(  # type: ignore
                         upper_bound, mean, std_dev
-                    ) - scipy.stats.norm.cdf(lower_bound, mean, std_dev)
+                    ) - scipy.stats.norm.cdf(lower_bound, mean, std_dev)  # type: ignore
                     probabilities[i] = probability
 
                 probabilities /= sum(probabilities)
@@ -638,16 +682,22 @@ class INegotiator(SAONegotiator):
             )
             return
 
-        opp_offer_val = self.opponent_ufun(self.opp_offer)
+        opp_offer_val = float(self.opponent_ufun(self.opp_offer))
         mean = 0.6 * opp_offer_val
 
         # Adjust std_dev to control the spread of the distribution
         # making it dynamic might not be optimal, need to test
-        std_dev = np.max(
-            np.array(
-                [(self.nmi.n_steps - self.current_step) / self.nmi.n_steps - 0.6, 0.1]
+        if self.nmi.n_steps is not None:
+            std_dev = np.max(
+                np.array(
+                    [
+                        (self.nmi.n_steps - self.current_step) / self.nmi.n_steps - 0.6,
+                        0.1,
+                    ]
+                )
             )
-        )
+        else:
+            std_dev = np.max(np.array([(1 - state.relative_time) - 0.6, 0.1]))
 
         # Calculate bucket boundaries
         bucket_boundaries = np.linspace(0, 1, self.num_of_hyp + 1)
@@ -655,6 +705,7 @@ class INegotiator(SAONegotiator):
         # Calculate probabilities for each bucket
         probabilities = copy.deepcopy(self.probability_prev)
 
+        index = 0
         for index, value in enumerate(probabilities):
             if opp_offer_val < self.opponents_reserved_value[index]:
                 # it should never be below, and the ones 20% closest to it as a percentage of number of hypothesis
@@ -668,7 +719,7 @@ class INegotiator(SAONegotiator):
                         break
                 probabilities[index] = 0
 
-        scale_additions = scipy.stats.norm.cdf(1, mean, std_dev)
+        scale_additions = scipy.stats.norm.cdf(1, mean, std_dev)  # type: ignore
         # scale_additions = 1
         for i in range(self.num_of_hyp):
             if probabilities[index] == 0:
@@ -676,9 +727,9 @@ class INegotiator(SAONegotiator):
             lower_bound = bucket_boundaries[i]
             upper_bound = bucket_boundaries[i + 1]
 
-            probability = scipy.stats.norm.cdf(
+            probability = scipy.stats.norm.cdf(  # type: ignore
                 upper_bound, mean, std_dev
-            ) - scipy.stats.norm.cdf(lower_bound, mean, std_dev)
+            ) - scipy.stats.norm.cdf(lower_bound, mean, std_dev)  # type: ignore
             probability /= scale_additions
             probabilities[i] += probability
 
@@ -708,9 +759,3 @@ class INegotiator(SAONegotiator):
             self.partner_reserved_value = 0.25
 
         # if you want to do a very small test, use the parameter small=True here. Otherwise, you can use the default parameters.
-
-
-if __name__ == "__main__":
-    from helpers.runner import run_a_tournament
-
-    run_a_tournament(Ingotiator, small=True, debug=False)

--- a/src/anl_agents/anl2024/team_191/others.py
+++ b/src/anl_agents/anl2024/team_191/others.py
@@ -103,7 +103,13 @@ class AwesomeNegotiator(SAONegotiator):
             for o in self.opponent_history[round(-0.2 * len(self.opponent_history)) :]
         ]
         # We consider the last 3% of the negotation as the final offers, or the final round in smaller negotations
-        end_game = state.relative_time >= 0.97 or state.step + 1 == self.nmi.n_steps
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        end_game = state.relative_time >= 0.97 or state.step + 1 == nsteps__
 
         # Accept a proposal under the following conditions:
         # The offer is better than the one that we are about to propose or the negotation is almost finished
@@ -227,7 +233,13 @@ class IngoNegotiator(SAONegotiator):
 
         self.initial_proposal = None
         self.initial_proposal_opp = None
-        self.total_steps = self.nmi.n_steps
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        self.total_steps = nsteps__
 
         self.partner_rv_prob = [0] * self.RV_granularity
         self.partner_rv_prob[0] = 1
@@ -296,7 +308,13 @@ class IngoNegotiator(SAONegotiator):
             for o in self.opponent_history[round(-0.2 * len(self.opponent_history)) :]
         ]
         # We consider the last 3% of the negotation as the final offers
-        end_game = state.relative_time >= 0.97 or state.step + 1 == self.nmi.n_steps
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        end_game = state.relative_time >= 0.97 or state.step + 1 == nsteps__
 
         # Never accept a proposal that is worse than our reservation value
         if self.ufun(offer) < self.ufun.reserved_value:
@@ -325,7 +343,12 @@ class IngoNegotiator(SAONegotiator):
         return np.argmin(dist_2)
 
     def current_phase(self, state):
-        percentage_complete = state.step / self.nmi.n_steps
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        percentage_complete = state.step / nsteps__
         if percentage_complete < 0.79:
             return 0
         elif percentage_complete < 0.97:
@@ -356,7 +379,13 @@ class IngoNegotiator(SAONegotiator):
         our_offers = []
         # Hyper parameters
         modifier = 0.5
-        chaos_threshold = 0.3 + (state.step / self.nmi.n_steps)
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        chaos_threshold = 0.3 + (state.step / nsteps__)
         # Get all possible offers
         pareto_points = self.pareto_calculations()
 
@@ -545,9 +574,13 @@ class IngoNegotiator(SAONegotiator):
             self.lambda_opp = np.log(np.max([ratio, 1])) / np.log(log_base)
 
             # compute discount factor using (10)
-            self.discount_ratio = (
-                self.current_step / self.nmi.n_steps
-            ) ** self.lambda_opp
+
+            nsteps__ = (
+                self.nmi.n_steps
+                if self.nmi.n_steps
+                else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+            )
+            self.discount_ratio = (self.current_step / nsteps__) ** self.lambda_opp
 
             # Compute Prob(proposal opp at t | res val of opp i ) using (9) for all i
             probability_proposal_given_rv = []

--- a/src/anl_agents/anl2024/team_205/kosagent.py
+++ b/src/anl_agents/anl2024/team_205/kosagent.py
@@ -115,8 +115,13 @@ class KosAgent(SAONegotiator):
             return True
 
         # 最後の一回になったら強制的に受け入れる
-        assert self.nmi.n_steps is not None
-        if self.nmi.n_steps - self.step == 1:
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        if nsteps__ - self.step == 1:
             if self.ufun(offer) > self.ufun.reserved_value:
                 return True
 
@@ -162,8 +167,14 @@ class KosAgent(SAONegotiator):
         # ステップ数の増加
         self.step = self.step + 1
         # 現在時刻の更新
-        assert self.nmi.n_steps is not None
-        self.current_time = self.step / self.nmi.n_steps
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        # assert self.nmi.n_steps is not None
+        self.current_time = self.step / nsteps__
 
 
 if __name__ == "__main__":

--- a/src/anl_agents/anl2024/team_209/bidding_strategy.py
+++ b/src/anl_agents/anl2024/team_209/bidding_strategy.py
@@ -1,28 +1,28 @@
 import random
 
 
-class BiddingStrategy():
+class BiddingStrategy:
     """
     Class responsible for the bidding strategy of our agent
     """
 
-    history : list = [] 
+    history: list = []
     "All bids received from the opponent"
-    order : list = []
+    order: list = []
     "Order of strategies our agent will go through"
-    order_index : int = 0
+    order_index: int = 0
     "Index of current strategy"
-    phase_settings : dict 
+    phase_settings: dict
     "Settings of the agent"
-    current_phase : str
+    current_phase: str
     """One of the possible phases of the agent, which switch depending on how much
     time has elapsed from the start of the session\n
     analysis -> stubborn -> compromising -> conceding"""
-    analysis_bids : int = 0
+    analysis_bids: int = 0
     "How many bids were already placed in analysis phase"
-    
-    stubborn_bid_index : int = 0
-    compromising_bid_index : int = 0
+
+    stubborn_bid_index: int = 0
+    compromising_bid_index: int = 0
     reservation_value: int = 0
 
     def __init__(self, agent, phase_settings=None):
@@ -32,12 +32,17 @@ class BiddingStrategy():
         agent: Our set up agent
         phase_settings: Dictionary with configuration
         """
-        self.steps_count = agent.nmi.n_steps
+
+        self.steps_count = (
+            agent.nmi.n_steps
+            if agent.nmi.n_steps is not None
+            else int(agent.nmi.state.time / agent.nmi.state.relative_time + 0.5)
+        )
         self.opponent_reserved_value = None
 
-        # Set random 
+        # Set random
         random.seed()
-        
+
         from .helpers.config import DEFAULT_SETTINGS
 
         # Parse setting to set the order of the bidding strategy
@@ -46,10 +51,11 @@ class BiddingStrategy():
 
         # Save all possible outcomes
         outcomes = [
-            self.Outcome(x, 
-              agent.ufun(x), 
-              agent.opponent_ufun(x),
-            ) 
+            self.Outcome(
+                x,
+                agent.ufun(x),
+                agent.opponent_ufun(x),
+            )
             for x in agent.nmi.outcome_space.enumerate_or_sample()
         ]
 
@@ -57,44 +63,50 @@ class BiddingStrategy():
         self.sorted_outcomes = sorted(outcomes, key=lambda x: x.utility, reverse=True)
 
         # Sort outcomes based on combined utility
-        self.sorted_combined_outcomes = sorted(outcomes, key=lambda x: x.combined_utility + x.utility, reverse=True)
+        self.sorted_combined_outcomes = sorted(
+            outcomes, key=lambda x: x.combined_utility + x.utility, reverse=True
+        )
 
         # Sorted outcomes in which our utility is higher
-        self.sorted_advantage_outcomes = [x for x in self.sorted_outcomes if x.utility >= x.opponent_utility]
+        self.sorted_advantage_outcomes = [
+            x for x in self.sorted_outcomes if x.utility >= x.opponent_utility
+        ]
 
         # Sorted utility for 'stubborn' phase
         self.sorted_stubborn_outcomes = sorted(
-            [x for x in self.sorted_combined_outcomes if x.utility >= self.reservation_value] ,
+            [
+                x
+                for x in self.sorted_combined_outcomes
+                if x.utility >= self.reservation_value
+            ],
             key=lambda x: x.combined_utility + x.utility,
-            reverse=True
+            reverse=True,
         )
 
         # All outcomes that are above our reservation value.
         # Might contain offers where the opponent is better of
         self.compromising_outcomes = sorted(
-            [x for x in self.sorted_outcomes if x.utility >= self.reservation_value] ,
-            key=lambda x: x.combined_utility + x.utility*self.phase_settings['compromising']['compromising_util_multiplier'],
-            reverse=True
-        ) 
-        
+            [x for x in self.sorted_outcomes if x.utility >= self.reservation_value],
+            key=lambda x: x.combined_utility
+            + x.utility
+            * self.phase_settings["compromising"]["compromising_util_multiplier"],
+            reverse=True,
+        )
+
         # [x for x in self.sorted_combined_outcomes if x.utility >= self.reservation_value]
-        #self.conceding = [x for x in self.sorted_outcomes if x.utility >= self.reserved_value and x.utility >= x.opponent_utility]
+        # self.conceding = [x for x in self.sorted_outcomes if x.utility >= self.reserved_value and x.utility >= x.opponent_utility]
         self.stubborn_bid_index = 0
         self.compromising_bid_index = 0
 
         self.analysis_bids = 0
         self.history = []
 
-    class Outcome():
+    class Outcome:
         """
         Class to store properties of an outcome
         """
-        def __init__(
-            self, 
-            outcome, 
-            utility,
-            opponent_utility
-        ):
+
+        def __init__(self, outcome, utility, opponent_utility):
             self.outcome = outcome
             self.utility = utility
             self.opponent_utility = opponent_utility
@@ -110,24 +122,25 @@ class BiddingStrategy():
     def parse_settings(self, settings):
         """
         Method to extract settings and set up the bidding strategy
-        
+
         settings: Dictionary with configuration
         """
         # Get order of the phases
-        self.order = list(settings['bidding-phases'].keys())
+        self.order = list(settings["bidding-phases"].keys())
         if self.steps_count < 35:
             self.order = [
-                x for x in self.order if 
-                not ('analysis' in x) and 
-                not ('stubborn' in x) and 
-                not ('conceding' in x) and
-                not ('irrational' in x)
+                x
+                for x in self.order
+                if "analysis" not in x
+                and "stubborn" not in x
+                and "conceding" not in x
+                and "irrational" not in x
             ]
 
         # Set current phase
         self.current_phase = self.order[0]
         # Store settings
-        self.phase_settings = settings['bidding-phases']
+        self.phase_settings = settings["bidding-phases"]
 
     def analysis_strategy(self):
         """
@@ -142,51 +155,57 @@ class BiddingStrategy():
         #
         # Randomly select index of the analytical bid
         # index = random.randint(0, 3)
-        
+
         # With 50% chance we select the bid which is either:
         # 1. very disadvantageous to our opponent
-        # 2. very disadvantageous to both of us, but we still have a higher utility  
+        # 2. very disadvantageous to both of us, but we still have a higher utility
         if bool(random.getrandbits(1)):
             # Disadvantageous to our opponent
             return self.sorted_outcomes[0].outcome
         else:
             # Disadvantageous to both of us
             return self.sorted_advantage_outcomes[-1].outcome
-    
+
     def stubborn_strategy(self):
         """
         Method responsible for the stubborn phase
         """
-        if self.phase_settings['stubborn']['irrationality'] > random.uniform(0.0, 1.0):
+        if self.phase_settings["stubborn"]["irrationality"] > random.uniform(0.0, 1.0):
             return self.irrational_strategy()
 
         bid = self.sorted_stubborn_outcomes[self.stubborn_bid_index]
         self.stubborn_bid_index += 1
 
-        if self.stubborn_bid_index >= int(len(self.sorted_stubborn_outcomes) * self.phase_settings['stubborn']['stubborn_bid_index_limit']):
+        if self.stubborn_bid_index >= int(
+            len(self.sorted_stubborn_outcomes)
+            * self.phase_settings["stubborn"]["stubborn_bid_index_limit"]
+        ):
             self.stubborn_bid_index = 0
 
         return bid.outcome
-    
+
     def compromising_strategy(self):
         """
         Method responsible for the compromising phase
         """
         bid = self.compromising_outcomes[self.compromising_bid_index]
-        if self.compromising_bid_index >= int(len(self.compromising_outcomes) * self.phase_settings['compromising']['compromising_bid_index_limit']):
+        if self.compromising_bid_index >= int(
+            len(self.compromising_outcomes)
+            * self.phase_settings["compromising"]["compromising_bid_index_limit"]
+        ):
             self.compromising_bid_index = 0
         else:
             self.compromising_bid_index += 1
 
         return bid.outcome
-    
+
     def irrational_strategy(self):
         """
         Method responsible for the irrational phase
         """
-    
+
         return self.sorted_advantage_outcomes[-1].outcome
-    
+
     def adapting_strategy(self):
         """
         Method responsible for the conceding phase
@@ -197,27 +216,29 @@ class BiddingStrategy():
             self.history = sorted(
                 [x for x in self.history if x.utility >= self.reservation_value],
                 key=lambda x: x.utility,
-                reverse=True
+                reverse=True,
             )
-            
+
             if len(self.history) > 0:
-                tmp_bids = [x for x in self.sorted_outcomes if 
-                    (x.utility >= self.reservation_value) and
-                    (x.opponent_utility >= self.opponent_reserved_value - 0.03) and
-                    (x.utility >= self.history[0].utility)
+                tmp_bids = [
+                    x
+                    for x in self.sorted_outcomes
+                    if (x.utility >= self.reservation_value)
+                    and (x.opponent_utility >= self.opponent_reserved_value - 0.03)
+                    and (x.utility >= self.history[0].utility)
                 ]
             else:
-                tmp_bids = [x for x in self.sorted_outcomes if 
-                    (x.utility >= self.reservation_value) and
-                    (x.opponent_utility >= self.opponent_reserved_value - 0.03)
+                tmp_bids = [
+                    x
+                    for x in self.sorted_outcomes
+                    if (x.utility >= self.reservation_value)
+                    and (x.opponent_utility >= self.opponent_reserved_value - 0.03)
                 ]
 
             bids = sorted(
-                tmp_bids,
-                key=lambda x: x.combined_utility + 3*x.utility,
-                reverse=True
+                tmp_bids, key=lambda x: x.combined_utility + 3 * x.utility, reverse=True
             )
-            
+
             if len(bids) > 0:
                 return bids[0].outcome
             else:
@@ -230,20 +251,20 @@ class BiddingStrategy():
     def update_phase(self, time_elapsed):
         """
         Phase switching mechanism
-        
+
         time_elapsed: How much time elapsed from the start of the tournament
         """
         if self.current_phase == "analysis":
-            # If we bid required number of bids for analysis, move to the next phase 
-            if self.analysis_bids == self.phase_settings['analysis']['analysis_length']:
+            # If we bid required number of bids for analysis, move to the next phase
+            if self.analysis_bids == self.phase_settings["analysis"]["analysis_length"]:
                 self.order_index += 1
                 self.current_phase = self.order[self.order_index]
         # If we reached time limit of the phase, move to the next one
-        elif self.phase_settings[self.current_phase]['time_limit'] < time_elapsed:
+        elif self.phase_settings[self.current_phase]["time_limit"] < time_elapsed:
             if not (self.order_index == len(self.order) - 1):
                 self.order_index += 1
             self.current_phase = self.order[self.order_index]
-        
+
         return self.current_phase
 
     def get_next_bid(self, state, opponent_reserved_value=None):
@@ -254,8 +275,10 @@ class BiddingStrategy():
         """
         self.opponent_reserved_value = opponent_reserved_value
         # Store the offer in history
-        self.history.extend([x for x in self.sorted_outcomes if x.outcome == state.current_offer])
+        self.history.extend(
+            [x for x in self.sorted_outcomes if x.outcome == state.current_offer]
+        )
         # Update current phase based on the elapsed time
         current_phase = self.update_phase(state.relative_time)
-        # Return bid based on the current phase 
+        # Return bid based on the current phase
         return self.__getattribute__(f"{current_phase.split('-')[0]}_strategy")()

--- a/src/anl_agents/anl2024/team_209/opponent_model.py
+++ b/src/anl_agents/anl2024/team_209/opponent_model.py
@@ -4,12 +4,12 @@ import math
 import warnings
 from .helpers.config import DEFAULT_SETTINGS
 
-OPPONENT_MODEL_SETTINGS = DEFAULT_SETTINGS['opponent_model']
+OPPONENT_MODEL_SETTINGS = DEFAULT_SETTINGS["opponent_model"]
 
 
 # single variable (step number) quadratic_polynomial function definition for nonlinear regression
 def quadratic_polynomial(x, a, b, c):
-    return a * x ** 2 + b * x + c
+    return a * x**2 + b * x + c
 
 
 # two-feature quadratic polynomial function definition for nonlinear regression
@@ -25,15 +25,17 @@ def pareto_distance(current_offer_utils, front):
     except:
         pass
 
+
 # Function to find Nash difference
-#def nash_diff(current_offer_utils, welfare):
-    #return welfare - sum(current_offer_utils)
+# def nash_diff(current_offer_utils, welfare):
+# return welfare - sum(current_offer_utils)
+
 
 def nash_diff(opponent_util, opponent_nash_util):
     return opponent_util - opponent_nash_util
 
 
-def update_reserved_value(agent: 'AwesomeNegotiator', offer):
+def update_reserved_value(agent, offer):
     """Learns the reserved value of the partner"""
     if offer is None:
         return
@@ -57,34 +59,48 @@ def update_reserved_value(agent: 'AwesomeNegotiator', offer):
 
     # Add current pareto distance to list
     if agent.pareto_front_exists:
-        agent.pareto_distances.append(pareto_distance([current_self_utility,current_opponent_utility], agent.frontier_utils))
+        agent.pareto_distances.append(
+            pareto_distance(
+                [current_self_utility, current_opponent_utility], agent.frontier_utils
+            )
+        )
     # Add current Nash Welfare difference to list
     if agent.nash_exists:
         # welfare of both
-        #agent.nash_diffs.append(nash_diff([current_self_utility,current_opponent_utility], agent.nash_welfare))
+        # agent.nash_diffs.append(nash_diff([current_self_utility,current_opponent_utility], agent.nash_welfare))
         # welfare of the opponent alone
-        agent.nash_diffs.append(nash_diff(current_opponent_utility, agent.nash_utils[1]))
-
+        agent.nash_diffs.append(
+            nash_diff(current_opponent_utility, agent.nash_utils[1])
+        )
 
     # Find window size
     # Find neg_phase
-    if (agent.nmi.state.step / agent.nmi.n_steps) <= 4/8:
+
+    nsteps__ = (
+        agent.nmi.n_steps
+        if agent.nmi.n_steps
+        else int(agent.nmi.state.time / agent.nmi.state.relative_time + 0.5)
+    )
+    if (agent.nmi.state.step / nsteps__) <= 4 / 8:
         agent.neg_phase = 0
-    elif (agent.nmi.state.step / agent.nmi.n_steps) <= 6/8:
+    elif (agent.nmi.state.step / nsteps__) <= 6 / 8:
         agent.neg_phase = 1
-    elif (agent.nmi.state.step / agent.nmi.n_steps) <= 7/8:
+    elif (agent.nmi.state.step / nsteps__) <= 7 / 8:
         agent.neg_phase = 2
     else:
         agent.neg_phase = 3
 
     # Find step_class
     step_ths = [100, 200, 500, 1000, 2500, 5000, 10000]
+
     for i, threshold in enumerate(step_ths):
-        if agent.nmi.n_steps <= threshold:
+        if nsteps__ <= threshold:
             agent.step_class = i
             break
 
-    window_size = OPPONENT_MODEL_SETTINGS['step_class']['step_'+str(agent.step_class)]['phase_'+str(agent.neg_phase)]
+    window_size = OPPONENT_MODEL_SETTINGS["step_class"][
+        "step_" + str(agent.step_class)
+    ]["phase_" + str(agent.neg_phase)]
 
     # if there are not enough bids to fill the window, go with what you've got.
     if len(agent.opponent_utilities) < window_size:
@@ -93,10 +109,12 @@ def update_reserved_value(agent: 'AwesomeNegotiator', offer):
         window_size = 3
 
     # based on the value of rv_feature_mode, use 1D, 2D
-    if OPPONENT_MODEL_SETTINGS['rv_feature_mode'] == 1 and agent.nash_exists:
+    if OPPONENT_MODEL_SETTINGS["rv_feature_mode"] == 1 and agent.nash_exists:
         if window_size < 6:
             window_size = 6
-        agent.opponent_ufun.reserved_value = interpolation_1(agent, window_size, agent.nash_diffs)
+        agent.opponent_ufun.reserved_value = interpolation_1(
+            agent, window_size, agent.nash_diffs
+        )
         agent.effective_rv_feature_mode = 1
     else:
         if window_size < 3:
@@ -106,16 +124,24 @@ def update_reserved_value(agent: 'AwesomeNegotiator', offer):
 
 
 # interpolation function for rv_feature_mode = 0 (round)
-def interpolation_0(agent: 'AwesomeNegotiator', window_size):
+def interpolation_0(agent, window_size):
     # if we did not reach window size, assume opponent rv is 1, highest.
     if len(agent.opponent_utilities) < window_size:
-        #agent.past_opponent_rv_list.append(1.0)
+        # agent.past_opponent_rv_list.append(1.0)
         return 1.0
 
     # else, xs are the last N (window_size) offer numbers of the opponent.
     # ys are the last N offers.
     else:
-        x = np.array(list(range(len(agent.opponent_utilities) - window_size, len(agent.opponent_utilities))), dtype=float)
+        x = np.array(
+            list(
+                range(
+                    len(agent.opponent_utilities) - window_size,
+                    len(agent.opponent_utilities),
+                )
+            ),
+            dtype=float,
+        )
         y = np.array(agent.opponent_utilities[-window_size:], dtype=float)
 
         try:
@@ -145,21 +171,44 @@ def interpolation_0(agent: 'AwesomeNegotiator', window_size):
             agent.past_opponent_rv_list.append(agent.opponent_utilities[-1])
             return agent.opponent_utilities[-1]
 
+
 # interpolation function for rv_feature_mode = 1 (round + Nash point distance) or rv_feature_mode = 2 (round + PF)
-def interpolation_1(agent: 'AwesomeNegotiator', window_size, f1):
+def interpolation_1(agent, window_size, f1):
     # if we did not reach window size, assume opponent rv is 1, highest.
     if len(agent.opponent_utilities) < window_size:
-        #agent.past_opponent_rv_list.append(1.0)
+        # agent.past_opponent_rv_list.append(1.0)
         return 1.0
 
     # else, xs are the last N (window_size) offer numbers of the opponent.
     # ys are the last N offers.
     else:
         if len(f1) == window_size:
-            x = np.array([list(range(len(agent.opponent_utilities) - window_size, len(agent.opponent_utilities))), [f1[0]] + f1[-window_size:-1]], dtype=float)
+            x = np.array(
+                [
+                    list(
+                        range(
+                            len(agent.opponent_utilities) - window_size,
+                            len(agent.opponent_utilities),
+                        )
+                    ),
+                    [f1[0]] + f1[-window_size:-1],
+                ],
+                dtype=float,
+            )
         else:
-            x = np.array([list(range(len(agent.opponent_utilities) - window_size, len(agent.opponent_utilities))), f1[-window_size-1:-1]], dtype=float)
-        y = np.array(agent.opponent_utilities[-window_size:],dtype=float)
+            x = np.array(
+                [
+                    list(
+                        range(
+                            len(agent.opponent_utilities) - window_size,
+                            len(agent.opponent_utilities),
+                        )
+                    ),
+                    f1[-window_size - 1 : -1],
+                ],
+                dtype=float,
+            )
+        y = np.array(agent.opponent_utilities[-window_size:], dtype=float)
 
         try:
             # Fit the curve.
@@ -167,21 +216,36 @@ def interpolation_1(agent: 'AwesomeNegotiator', window_size, f1):
             params, covariance = curve_fit(quadratic_2D, x, y)
             warnings.filterwarnings("default")
 
-            optimized_a, optimized_b, optimized_c, optimized_d, optimized_e, optimized_f = params
+            (
+                optimized_a,
+                optimized_b,
+                optimized_c,
+                optimized_d,
+                optimized_e,
+                optimized_f,
+            ) = params
 
             # predict next offer of the opponent
-            x_pred = np.array([[len(agent.opponent_utilities)], [f1[len(f1)-1]]])
-            #print(x_pred)
+            x_pred = np.array([[len(agent.opponent_utilities)], [f1[len(f1) - 1]]])
+            # print(x_pred)
             # i'll check if y_pred decreased inside update_reserved_value func
             # use fitted curve parameters to predict next offer of the opponent (the reservation value).
-            y_pred = quadratic_2D(x_pred, optimized_a, optimized_b, optimized_c, optimized_d, optimized_e, optimized_f)
+            y_pred = quadratic_2D(
+                x_pred,
+                optimized_a,
+                optimized_b,
+                optimized_c,
+                optimized_d,
+                optimized_e,
+                optimized_f,
+            )
             if y_pred[0] < 0:
                 y_pred[0] = 0
             elif y_pred[0] > 1:
                 y_pred[0] = 1
             agent.past_opponent_rv_list.append(y_pred[0])
 
-            #print(y_pred)
+            # print(y_pred)
             return y_pred[0]
         except:
             # If we for any reason (e.g. non-convergence) then we use last opponent offer utility as opponent RV

--- a/src/anl_agents/anl2024/team_232/tak.py
+++ b/src/anl_agents/anl2024/team_232/tak.py
@@ -78,7 +78,13 @@ class TAKAgent(SAONegotiator):
         self.partner_reserved_value = self.ufun.reserved_value
 
         self.opponent_ufun.reserved_value = self.ufun.reserved_value
-        self.negotiation_duration = self.nmi.n_steps
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        self.negotiation_duration = nsteps__
 
     def __call__(self, state: SAOState) -> SAOResponse:
         """

--- a/src/anl_agents/anl2024/team_moto/uoagent.py
+++ b/src/anl_agents/anl2024/team_moto/uoagent.py
@@ -209,8 +209,13 @@ class UOAgent(SAONegotiator):
             offer_list = sorted(self.outcome_list[num1:num2+1], key=lambda x:(x[1], x[2]), reverse=True)
             offer, social_utility, my_utility, opponent_utility = offer_list[0]
             """
-            assert self.nmi.n_steps is not None
-            value = 1.0 - (1.0 - self.under) * ((self.step / self.nmi.n_steps) ** 5)
+            nsteps__ = (
+                self.nmi.n_steps
+                if self.nmi.n_steps
+                else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+            )
+            # assert self.nmi.n_steps is not None
+            value = 1.0 - (1.0 - self.under) * ((self.step / nsteps__) ** 5)
             listing = map(lambda x: x[2], self.outcome_list)
             ufunlist = list(listing)
             num1 = self.getNearestValue(ufunlist, value + 0.02)

--- a/src/anl_agents/anl2024/team_twistin/group5.py
+++ b/src/anl_agents/anl2024/team_twistin/group5.py
@@ -88,7 +88,13 @@ class Group5(SAONegotiator):
         self.partner_reserved_value = 0
         self.opponent_offer_history = list()
         self.opponent_offer_history2 = list()
-        self.deadline = self.ami.n_steps  # Only takes into account a step limit, not time limit. Should it be expanded?
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        self.deadline = nsteps__  # Only takes into account a step limit, not time limit. Should it be expanded?
         self.opponent_rv_range = [0.0, 1.0]
         self.n_estimation_areas = 100
         self.estimation_areas = list()
@@ -192,7 +198,13 @@ class Group5(SAONegotiator):
         because the last part rejects all the offers that are really bad,
         it is safe to accept the last offer that is made in the negotiation.
         """
-        if self.nmi.n_steps == state.step:
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        if nsteps__ == state.step:
             return True
 
         """
@@ -217,7 +229,13 @@ class Group5(SAONegotiator):
         It will reject any offer that is not in the top of offers that we have recieved so far.
         This window will shrink as the negotiation goes on.
         """
-        time_remaining = self.nmi.n_steps - state.step
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        time_remaining = nsteps__ - state.step
         if state.relative_time > 0.9:
             for x in self.opponent_offer_history2[-time_remaining:]:
                 if x > self.ufun(offer):
@@ -286,10 +304,16 @@ class Group5(SAONegotiator):
         """
 
         # Adjusted time function
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
         if self.first_bidder:
-            time = state.step / self.nmi.n_steps
+            time = state.step / nsteps__
         else:
-            time = (state.step + 1) / self.nmi.n_steps
+            time = (state.step + 1) / nsteps__
 
         # Calculate the concession rate based on function described in paper
         power = 1 / self.psi
@@ -308,10 +332,16 @@ class Group5(SAONegotiator):
         """
 
         # Adjusted time function
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
         if self.first_bidder:
-            time = state.step / self.nmi.n_steps
+            time = state.step / nsteps__
         else:
-            time = (state.step + 1) / self.nmi.n_steps
+            time = (state.step + 1) / nsteps__
 
         # Return concession if lower part of ratio function is 0
         if concession == 0 or time == 1:

--- a/src/anl_agents/anl2024/teamkb/agentkb.py
+++ b/src/anl_agents/anl2024/teamkb/agentkb.py
@@ -124,7 +124,12 @@ class AgentKB(SAONegotiator):
         offer = state.current_offer
 
         # 超妥協フェーズ
-        if self.step == self.nmi.n_steps:
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        if self.step == nsteps__:
             if offer in self.rational_outcomes:
                 com_val = self.make_threshold_depend_on_reservation(
                     m=self.m2, n=self.n2
@@ -161,7 +166,12 @@ class AgentKB(SAONegotiator):
         # The opponent's ufun can be accessed using parter_ufun, which is not used yet.
 
         # 超妥協フェーズ
-        if self.step == self.nmi.n_steps:
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        if self.step == nsteps__:
             com_val = self.make_threshold_depend_on_reservation(m=self.m2, n=self.n2)
 
             choose_bid = self.get_target_bid(com_val, self.frontier_outcomes)

--- a/src/anl_agents/anl2024/tipsonly/katla_nir_aent.py
+++ b/src/anl_agents/anl2024/tipsonly/katla_nir_aent.py
@@ -212,7 +212,13 @@ class KatlaNirAgent(SAONegotiator):
         # initialize the parameters
         self.IP = 101 - self.ufun(self.ufun.best()) * 100
         self.RP = 100 - self.reserved_value * 100
-        self.T = self.nmi.n_steps
+
+        nsteps__ = (
+            self.nmi.n_steps
+            if self.nmi.n_steps
+            else int(self.nmi.state.time / self.nmi.state.relative_time + 0.5)
+        )
+        self.T = nsteps__
         self.beta = 1.6
         self.N = (3, 3)
         self.HISTORY = []


### PR DESCRIPTION
Added a simple way to make agents compatible with time-limit negotiations

1. If nmi.n_steps is given, the agent behaves exactly the same. This includes keeping some of the clear bugs (e.g. comparing step with n_steps)
2. If nmi.n_steps is None, we estimate the number of steps as (time / relative_time). This should be kind of OK as long as time_limit is given.

A better way is to use nmi.estimated_n_steps which is to be added in negmas 0.10.24 (currently on github).